### PR TITLE
Add test suite and fix proxy bugs for MCPB extension

### DIFF
--- a/docs/mcpb-extension/.mcpbignore
+++ b/docs/mcpb-extension/.mcpbignore
@@ -1,0 +1,4 @@
+# Don't bundle tests or build artifacts in the .mcpb package
+tests/
+*.mcpb
+.mcpbignore

--- a/docs/mcpb-extension/proxy/squid.conf
+++ b/docs/mcpb-extension/proxy/squid.conf
@@ -4,14 +4,15 @@
 # Listening port
 http_port 3128
 
+# PID file location (must be on writable tmpfs in read-only container)
+pid_filename /var/run/squid/squid.pid
+
 # Access Control Lists (ACLs)
 # Define what "Atlassian domains" means
 acl atlassian_cloud dstdomain .atlassian.net
 acl atlassian_cloud dstdomain .jira.com
 acl atlassian_cloud dstdomain .jira-dev.com
 acl atlassian_cloud dstdomain .atlassian.com
-acl atlassian_cloud dstdomain atlassian.com
-acl atlassian_cloud dstdomain api.atlassian.com
 
 # SSL/TLS ports (CONNECT method)
 acl SSL_ports port 443
@@ -27,8 +28,8 @@ http_access deny !Safe_ports
 # Block CONNECT to non-SSL ports
 http_access deny CONNECT !SSL_ports
 
-# Allow localhost (for Squid itself)
-acl localhost src 127.0.0.1/32 ::1
+# Allow connections from within the Docker network
+# (Squid has a built-in 'localhost' ACL so we don't redefine it)
 http_access allow localhost
 
 # MAIN RULE: Allow ONLY Atlassian domains
@@ -37,9 +38,9 @@ http_access allow atlassian_cloud
 # Deny everything else
 http_access deny all
 
-# Logging (to container stdout for debugging)
-access_log stdio:/dev/stdout squid
-cache_log /dev/stdout
+# Logging (to container stderr for debugging)
+access_log stdio:/dev/stderr squid
+cache_log stdio:/dev/stderr
 
 # Disable caching (we're just a filtering proxy)
 cache deny all

--- a/docs/mcpb-extension/server/index.js
+++ b/docs/mcpb-extension/server/index.js
@@ -9,7 +9,7 @@ const path = require("path");
 const fs = require("fs");
 
 // --- Configuration ---
-const IMAGE = "ghcr.io/sooperset/mcp-atlassian:v0.11.10";
+const IMAGE = "ghcr.io/troubladore/mcp-atlassian:v0.11.10";
 const PROXY_IMAGE = "eruditis/atlassian-proxy:latest";
 const PROXY_CONTAINER_NAME = "eruditis-atlassian-proxy";
 const PROXY_PORT = 3128;
@@ -148,9 +148,9 @@ function ensureProxyRunning() {
         --cap-drop=ALL \
         --security-opt no-new-privileges:true \
         --read-only \
-        --tmpfs /var/cache/squid:noexec,nosuid,size=64m \
-        --tmpfs /var/log/squid:noexec,nosuid,size=16m \
-        --tmpfs /var/run/squid:noexec,nosuid,size=8m \
+        --tmpfs /var/cache/squid:noexec,nosuid,size=64m,uid=31,gid=31 \
+        --tmpfs /var/log/squid:noexec,nosuid,size=16m,uid=31,gid=31 \
+        --tmpfs /var/run/squid:noexec,nosuid,size=8m,uid=31,gid=31 \
         ${PROXY_IMAGE}`,
       { stdio: 'inherit' }
     );

--- a/docs/mcpb-extension/tests/integration.test.js
+++ b/docs/mcpb-extension/tests/integration.test.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// Integration tests for the mcpb-extension.
+// These require Docker to be running. Run with:
+//   node --test tests/integration.test.js
+//
+// Tests are ordered: proxy build -> proxy runtime -> mcp-atlassian e2e
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const { execSync } = require("node:child_process");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+const PROXY_DIR = path.join(ROOT, "proxy");
+const PROXY_IMAGE = "eruditis/atlassian-proxy:test";
+const PROXY_CONTAINER = "mcpb-test-proxy";
+const NETWORK = "mcpb-test-net";
+const MCP_IMAGE = "ghcr.io/troubladore/mcp-atlassian:v0.11.10";
+
+function exec(cmd, opts = {}) {
+  return execSync(cmd, { encoding: "utf-8", timeout: 120000, ...opts }).trim();
+}
+
+function execQuiet(cmd) {
+  try {
+    return exec(cmd, { stdio: "pipe" });
+  } catch (e) {
+    return e.stderr || e.stdout || e.message;
+  }
+}
+
+// =============================================================================
+// Proxy Docker build
+// =============================================================================
+describe("proxy Docker image", () => {
+  it("builds successfully from proxy/Dockerfile", () => {
+    const output = exec(
+      `docker build -t ${PROXY_IMAGE} ${PROXY_DIR} 2>&1`
+    );
+    assert.ok(
+      output.includes("naming to") || output.includes("exporting to image"),
+      `Docker build did not complete successfully:\n${output.slice(-500)}`
+    );
+  });
+});
+
+// =============================================================================
+// Proxy container runtime
+// =============================================================================
+describe("proxy container runtime", () => {
+  before(() => {
+    // Clean up any leftover test containers/networks
+    execQuiet(`docker rm -f ${PROXY_CONTAINER}`);
+    execQuiet(`docker network rm ${NETWORK}`);
+    exec(`docker network create ${NETWORK}`);
+  });
+
+  after(() => {
+    execQuiet(`docker rm -f ${PROXY_CONTAINER}`);
+    execQuiet(`docker network rm ${NETWORK}`);
+  });
+
+  it("starts and stays running with read-only filesystem and hardened tmpfs", () => {
+    exec(
+      `docker run -d --name ${PROXY_CONTAINER} \
+        --network=${NETWORK} \
+        --cap-drop=ALL \
+        --security-opt no-new-privileges:true \
+        --read-only \
+        --tmpfs /var/cache/squid:noexec,nosuid,size=64m,uid=31,gid=31 \
+        --tmpfs /var/log/squid:noexec,nosuid,size=16m,uid=31,gid=31 \
+        --tmpfs /var/run/squid:noexec,nosuid,size=8m,uid=31,gid=31 \
+        ${PROXY_IMAGE}`
+    );
+
+    // Wait for container to stabilize
+    execSync("sleep 3");
+
+    const status = exec(
+      `docker inspect ${PROXY_CONTAINER} --format "{{.State.Status}}"`
+    );
+    assert.equal(status, "running", `Proxy container is not running (status: ${status})`);
+  });
+
+  it("listens on port 3128", () => {
+    const result = exec(
+      `docker exec ${PROXY_CONTAINER} nc -z 127.0.0.1 3128 && echo OK`
+    );
+    assert.equal(result, "OK", "Proxy not listening on port 3128");
+  });
+
+  it("runs as non-root user", () => {
+    const user = exec(
+      `docker exec ${PROXY_CONTAINER} whoami 2>/dev/null || docker exec ${PROXY_CONTAINER} id -un`
+    );
+    assert.notEqual(user, "root", "Proxy must not run as root");
+  });
+
+  it("has security hardening applied", () => {
+    const inspect = exec(
+      `docker inspect ${PROXY_CONTAINER} --format "{{json .HostConfig.SecurityOpt}} {{json .HostConfig.CapDrop}} {{json .HostConfig.ReadonlyRootfs}}"`
+    );
+    assert.ok(inspect.includes("no-new-privileges"), "Missing no-new-privileges");
+    assert.ok(inspect.includes("ALL"), "Missing cap-drop ALL");
+    assert.ok(inspect.includes("true"), "Missing read-only rootfs");
+  });
+});
+
+// =============================================================================
+// MCP end-to-end
+// =============================================================================
+describe("mcp-atlassian end-to-end", () => {
+  before(() => {
+    // Ensure proxy and network are running from previous suite
+    // If previous suite cleaned up, recreate
+    execQuiet(`docker network create ${NETWORK}`);
+    const proxyRunning = execQuiet(
+      `docker ps --filter name=${PROXY_CONTAINER} --filter status=running -q`
+    );
+    if (!proxyRunning) {
+      execQuiet(`docker rm -f ${PROXY_CONTAINER}`);
+      exec(
+        `docker run -d --name ${PROXY_CONTAINER} \
+          --network=${NETWORK} \
+          --cap-drop=ALL \
+          --security-opt no-new-privileges:true \
+          --read-only \
+          --tmpfs /var/cache/squid:noexec,nosuid,size=64m,uid=31,gid=31 \
+          --tmpfs /var/log/squid:noexec,nosuid,size=16m,uid=31,gid=31 \
+          --tmpfs /var/run/squid:noexec,nosuid,size=8m,uid=31,gid=31 \
+          ${PROXY_IMAGE}`
+      );
+      execSync("sleep 3");
+    }
+  });
+
+  after(() => {
+    // Final cleanup
+    execQuiet(`docker rm -f ${PROXY_CONTAINER}`);
+    execQuiet(`docker network rm ${NETWORK}`);
+  });
+
+  it("mcp-atlassian image exists locally", () => {
+    const result = execQuiet(`docker image inspect ${MCP_IMAGE} 2>&1`);
+    assert.ok(
+      !result.includes("No such image"),
+      `Image ${MCP_IMAGE} not found locally. Run: docker build -t ${MCP_IMAGE} . from repo root`
+    );
+  });
+
+  it("responds to MCP initialize with valid protocol response", () => {
+    const initMsg = JSON.stringify({
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test", version: "0.1.0" },
+      },
+      jsonrpc: "2.0",
+      id: 0,
+    });
+
+    const output = exec(
+      `echo '${initMsg}' | timeout 15 docker run --rm -i \
+        --network=${NETWORK} \
+        --cap-drop=ALL \
+        --security-opt no-new-privileges:true \
+        --read-only \
+        --tmpfs /tmp:noexec,nosuid,size=64m \
+        --memory=256m \
+        --cpus=0.5 \
+        -e CONFLUENCE_URL=https://test.atlassian.net/wiki \
+        -e CONFLUENCE_USERNAME=test@test.com \
+        -e CONFLUENCE_API_TOKEN=fake-token \
+        -e JIRA_URL=https://test.atlassian.net \
+        -e JIRA_USERNAME=test@test.com \
+        -e JIRA_API_TOKEN=fake-token \
+        -e ENABLED_TOOLS=confluence_search \
+        -e HTTP_PROXY=http://${PROXY_CONTAINER}:3128 \
+        -e HTTPS_PROXY=http://${PROXY_CONTAINER}:3128 \
+        -e NO_PROXY=localhost,127.0.0.1 \
+        ${MCP_IMAGE} 2>/dev/null`,
+      { timeout: 30000 }
+    );
+
+    // Parse the JSON response
+    let response;
+    try {
+      response = JSON.parse(output.split("\n")[0]);
+    } catch (e) {
+      assert.fail(`Failed to parse MCP response as JSON: ${output.slice(0, 200)}`);
+    }
+
+    assert.equal(response.jsonrpc, "2.0", "Must be JSON-RPC 2.0");
+    assert.equal(response.id, 0, "Must respond to id 0");
+    assert.ok(response.result, "Must have a result field");
+    assert.ok(
+      response.result.serverInfo,
+      "Must include serverInfo"
+    );
+    assert.ok(
+      response.result.protocolVersion,
+      "Must include protocolVersion"
+    );
+  });
+});

--- a/docs/mcpb-extension/tests/static.test.js
+++ b/docs/mcpb-extension/tests/static.test.js
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+// Static analysis tests for the mcpb-extension.
+// These validate config files and scripts for known pitfalls
+// without requiring Docker. Run with: node --test tests/
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "..");
+
+// --- Helper: read file relative to extension root ---
+function readFile(relPath) {
+  return fs.readFileSync(path.join(ROOT, relPath), "utf-8");
+}
+
+// =============================================================================
+// squid.conf tests
+// =============================================================================
+describe("proxy/squid.conf", () => {
+  const conf = readFile("proxy/squid.conf");
+
+  it("has no redundant domain entries that Squid 6.6 rejects", () => {
+    // Squid 6.6 treats '.example.com' as covering 'example.com' and
+    // 'sub.example.com'. Having both '.example.com' and 'example.com'
+    // in the same ACL is a FATAL error.
+    const domainLines = conf
+      .split("\n")
+      .filter((line) => line.match(/^\s*acl\s+\S+\s+dstdomain\s+/))
+      .map((line) => {
+        const parts = line.trim().split(/\s+/);
+        return { acl: parts[1], domain: parts[3] };
+      });
+
+    // Group by ACL name
+    const aclGroups = {};
+    for (const { acl, domain } of domainLines) {
+      if (!aclGroups[acl]) aclGroups[acl] = [];
+      aclGroups[acl].push(domain);
+    }
+
+    // For each ACL, check that no wildcard domain (starting with '.')
+    // has a redundant bare or sub-domain entry
+    for (const [acl, domains] of Object.entries(aclGroups)) {
+      const wildcards = domains.filter((d) => d.startsWith("."));
+      for (const wildcard of wildcards) {
+        const baseDomain = wildcard.slice(1); // '.atlassian.com' -> 'atlassian.com'
+        for (const domain of domains) {
+          if (domain === wildcard) continue;
+          // Check if this domain is covered by the wildcard
+          if (domain === baseDomain || domain.endsWith(baseDomain)) {
+            assert.fail(
+              `ACL '${acl}': domain '${domain}' is redundant — already covered by wildcard '${wildcard}'. ` +
+                `Squid 6.6 treats this as a fatal error.`
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("sets pid_filename to a path under /var/run/squid/ (writable tmpfs)", () => {
+    const pidLine = conf
+      .split("\n")
+      .find((line) => line.match(/^\s*pid_filename\s+/));
+    assert.ok(pidLine, "squid.conf must set pid_filename explicitly");
+    const pidPath = pidLine.trim().split(/\s+/)[1];
+    assert.ok(
+      pidPath.startsWith("/var/run/squid/"),
+      `pid_filename must be under /var/run/squid/ (writable tmpfs), got: ${pidPath}`
+    );
+  });
+
+  it("does not define a custom localhost ACL (uses Squid built-in)", () => {
+    // Squid has a built-in 'localhost' ACL. Redefining it causes warnings.
+    const localhostAcl = conf
+      .split("\n")
+      .find((line) => line.match(/^\s*acl\s+localhost\s+src\s+/));
+    assert.equal(
+      localhostAcl,
+      undefined,
+      `squid.conf should not redefine 'acl localhost src ...' — Squid has a built-in localhost ACL. ` +
+        `Found: ${localhostAcl}`
+    );
+  });
+
+  it("listens on port 3128", () => {
+    assert.match(conf, /http_port\s+3128/, "Must listen on port 3128");
+  });
+
+  it("denies all traffic by default", () => {
+    assert.match(
+      conf,
+      /http_access\s+deny\s+all/,
+      "Must have a default deny rule"
+    );
+  });
+
+  it("only allows Atlassian domains", () => {
+    // Collect all 'http_access allow' rules (excluding localhost)
+    const allowRules = conf
+      .split("\n")
+      .filter((line) => line.match(/^\s*http_access\s+allow\s+/))
+      .filter((line) => !line.includes("localhost"));
+
+    assert.equal(
+      allowRules.length,
+      1,
+      `Expected exactly 1 non-localhost allow rule, got ${allowRules.length}: ${allowRules.join(", ")}`
+    );
+    assert.match(
+      allowRules[0],
+      /atlassian_cloud/,
+      "The only allow rule must reference atlassian_cloud ACL"
+    );
+  });
+
+  it("blocks direct IP access", () => {
+    assert.match(
+      conf,
+      /http_access\s+deny\s+numeric_IPs/,
+      "Must block direct IP access to prevent domain filter bypass"
+    );
+  });
+});
+
+// =============================================================================
+// server/index.js tests
+// =============================================================================
+describe("server/index.js", () => {
+  const serverJs = readFile("server/index.js");
+
+  it("references troubladore image (not upstream sooperset)", () => {
+    assert.match(
+      serverJs,
+      /ghcr\.io\/troubladore\/mcp-atlassian/,
+      "IMAGE must reference ghcr.io/troubladore/mcp-atlassian"
+    );
+    assert.doesNotMatch(
+      serverJs,
+      /ghcr\.io\/sooperset\/mcp-atlassian/,
+      "Must NOT reference upstream ghcr.io/sooperset/mcp-atlassian"
+    );
+  });
+
+  it("pins image to a specific version tag (not :latest)", () => {
+    const imageMatch = serverJs.match(
+      /const\s+IMAGE\s*=\s*"([^"]+)"/
+    );
+    assert.ok(imageMatch, "IMAGE constant must be defined");
+    const image = imageMatch[1];
+    assert.ok(
+      !image.endsWith(":latest"),
+      `IMAGE must be pinned to a specific version, got: ${image}`
+    );
+    assert.match(
+      image,
+      /:\S+$/,
+      `IMAGE must include a version tag, got: ${image}`
+    );
+  });
+
+  it("drops all capabilities (--cap-drop=ALL)", () => {
+    // Must appear in both proxy and mcp-atlassian container commands
+    const capDropCount = (serverJs.match(/--cap-drop=ALL/g) || []).length;
+    assert.ok(
+      capDropCount >= 2,
+      `Expected --cap-drop=ALL at least twice (proxy + main container), found ${capDropCount}`
+    );
+  });
+
+  it("sets no-new-privileges on all containers", () => {
+    const secOptCount = (
+      serverJs.match(/no-new-privileges:true/g) || []
+    ).length;
+    assert.ok(
+      secOptCount >= 2,
+      `Expected no-new-privileges:true at least twice, found ${secOptCount}`
+    );
+  });
+
+  it("uses read-only filesystem on all containers", () => {
+    const readOnlyCount = (serverJs.match(/--read-only/g) || []).length;
+    assert.ok(
+      readOnlyCount >= 2,
+      `Expected --read-only at least twice, found ${readOnlyCount}`
+    );
+  });
+
+  it("has no volume mounts (-v)", () => {
+    // Look for docker run with -v flag (but not inside comments)
+    const codeLines = serverJs
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"));
+    const volumeMounts = codeLines.filter((line) =>
+      line.match(/\s-v\s+\S+:\S+/)
+    );
+    assert.equal(
+      volumeMounts.length,
+      0,
+      `Found volume mounts that expose host filesystem: ${volumeMounts.join(", ")}`
+    );
+  });
+
+  it("has no host network mode", () => {
+    const codeLines = serverJs
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"));
+    const hostNet = codeLines.filter((line) =>
+      line.includes("--network=host")
+    );
+    assert.equal(
+      hostNet.length,
+      0,
+      "Must not use --network=host (breaks proxy isolation)"
+    );
+  });
+
+  it("sets uid/gid on proxy tmpfs mounts (squid runs as uid 31)", () => {
+    // All proxy tmpfs lines must include uid=31,gid=31
+    const proxyTmpfsLines = serverJs
+      .split("\n")
+      .filter(
+        (line) =>
+          line.includes("--tmpfs /var/") && line.includes("squid")
+      );
+    assert.ok(
+      proxyTmpfsLines.length >= 3,
+      `Expected at least 3 proxy tmpfs mounts, found ${proxyTmpfsLines.length}`
+    );
+    for (const line of proxyTmpfsLines) {
+      assert.match(
+        line,
+        /uid=31/,
+        `Proxy tmpfs mount missing uid=31: ${line.trim()}`
+      );
+      assert.match(
+        line,
+        /gid=31/,
+        `Proxy tmpfs mount missing gid=31: ${line.trim()}`
+      );
+    }
+  });
+
+  it("never exposes delete operations in tool arrays", () => {
+    // Filter out comment lines — the comment documenting what's excluded is fine
+    const codeLines = serverJs
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"))
+      .join("\n");
+    assert.doesNotMatch(
+      codeLines,
+      /jira_delete_issue/,
+      "jira_delete_issue must never appear in tool arrays"
+    );
+    assert.doesNotMatch(
+      codeLines,
+      /confluence_delete_page/,
+      "confluence_delete_page must never appear in tool arrays"
+    );
+  });
+
+  it("defaults write tools to disabled", () => {
+    assert.match(
+      serverJs,
+      /["']false["']/,
+      "ENABLE_WRITE must default to 'false'"
+    );
+  });
+});
+
+// =============================================================================
+// manifest.json tests
+// =============================================================================
+describe("manifest.json", () => {
+  const manifest = JSON.parse(readFile("manifest.json"));
+
+  it("marks API token as sensitive", () => {
+    assert.ok(
+      manifest.user_config?.atlassian_api_token?.sensitive === true,
+      "atlassian_api_token must have sensitive: true"
+    );
+  });
+
+  it("defaults write tools to false", () => {
+    assert.equal(
+      manifest.user_config?.enable_write_tools?.default,
+      "false",
+      "enable_write_tools must default to 'false'"
+    );
+  });
+
+  it("has a pinned version (not 0.0.0)", () => {
+    assert.ok(
+      manifest.version && manifest.version !== "0.0.0",
+      `manifest version must be set, got: ${manifest.version}`
+    );
+  });
+
+  it("uses correct extension name", () => {
+    assert.equal(
+      manifest.name,
+      "eruditis-atlassian",
+      "Extension name must be eruditis-atlassian"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Fix three proxy bugs discovered during Claude Desktop testing:
  - Squid 6.6 rejects redundant ACL domain entries (`.atlassian.com` already covers `atlassian.com`)
  - Squid PID file needs explicit path on writable tmpfs (`--read-only` filesystem)
  - Docker `--tmpfs` mounts need `uid=31,gid=31` for non-root Squid user
- Add 28 automated tests (Node.js built-in test runner, zero dependencies):
  - 21 static analysis tests validating squid.conf, server/index.js, manifest.json
  - 7 Docker integration tests (proxy build, runtime hardening, MCP e2e handshake)
- Switch Docker image reference from upstream `sooperset` to `troubladore` GHCR
- Update BUILD_NOTES.md with complete build/push/pack workflow and known pitfalls
- Add `.mcpbignore` to exclude tests from packaged `.mcpb` extension

## Test plan

- [ ] Run static tests: `cd docs/mcpb-extension && node --test tests/static.test.js` (21 pass)
- [ ] Run integration tests: `node --test tests/integration.test.js` (7 pass, requires Docker)
- [ ] Verify regression detection: reintroduce a bug and confirm tests fail
- [ ] Rebuild `.mcpb` and verify tests directory is excluded from package

🤖 Generated with [Claude Code](https://claude.com/claude-code)