### PR TITLE
docs: add upstream contribution workflow and PR tracking

### DIFF
--- a/.claude/rules/upstream-merge.md
+++ b/.claude/rules/upstream-merge.md
@@ -11,21 +11,31 @@ This is a fork of `sooperset/mcp-atlassian`. Remotes:
 - `origin` = `Troubladore/mcp-atlassian` (our fork)
 - `upstream` = `sooperset/mcp-atlassian` (upstream)
 
-## Merge process
+## Sync process (rebase, not merge)
 
-1. `git fetch upstream && git merge upstream/main` into `eruditis/main`
-2. Resolve conflicts — favor upstream's structure, preserve fork features
-3. Run `uv run ruff format .` and `uv run ruff check --fix .` after resolution
-4. Run `uv run pytest tests/ -x` to verify
-5. Create feature branch and PR to `eruditis/main`
+We rebase `eruditis/main` onto `main` to keep a clean stack of fork-specific commits.
 
-## Fork-specific features to preserve during merges
+```bash
+git checkout main && git pull upstream main && git push origin main
+git checkout eruditis/main && git rebase main
+# Resolve conflicts, then:
+uv run ruff format . && uv run ruff check --fix .
+uv run pytest tests/ -x
+git push --force-with-lease origin eruditis/main
+```
 
-- Page hierarchy navigation (get_page_ancestors, get_space_page_tree, list_spaces, move_page_position)
-- Page width support (page_width parameter on create/update)
-- URL auto-parsing (parse_page_id_from_url helper)
+## Fork-specific features to preserve during rebases
+
+- Error recovery / fuzzy matching (utils/suggestions.py, servers/confluence.py, servers/main.py)
+- Page hierarchy (get_space_page_tree in pages.py and servers/confluence.py)
+- Page width support (page_width on ConfluencePage model, create/update)
+- Delete safety filter (ALLOW_DELETE_TOOLS, "delete" tag filtering)
+- URL security fix (endswith() in urls.py)
 - MCPB extension (docs/mcpb-extension/)
 - Security docs (security/)
+- Fork CI config, Claude rules, plans docs
+
+**Note:** Some of these have been proposed upstream (see docs/UPSTREAM_CONTRIBUTIONS.md). As upstream merges them, they leave our fork diff and no longer need preserving.
 
 ## Where conflicts typically occur
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,29 @@ gh issue create \
   --body "Issue body here"
 ```
 
+## Upstream Alignment
+
+Our fork is rebased on upstream `main`, keeping fork-specific commits as a clean stack on top. See `docs/UPSTREAM_CONTRIBUTIONS.md` for the full workflow.
+
+**Quick reference:**
+```bash
+# Sync main with upstream
+git checkout main && git pull upstream main && git push origin main
+
+# Rebase fork onto latest upstream
+git checkout eruditis/main && git rebase main
+
+# Check status of our upstream PRs
+for pr in 1087 1088 1090 1091 1092; do
+  echo -n "PR #$pr: "; gh pr view $pr --repo sooperset/mcp-atlassian --json state -q '.state'
+done
+```
+
+**Auth context for upstream PRs:** The fine-grained PAT (`github_pat_`) cannot create cross-repo PRs. Switch to the classic PAT first:
+```bash
+gh auth login    # Select github.com, paste the classic token (ghp_...)
+```
+
 ## Docker
 
 Images are pushed to GHCR under `ghcr.io/troubladore/mcp-atlassian`.

--- a/docs/UPSTREAM_CONTRIBUTIONS.md
+++ b/docs/UPSTREAM_CONTRIBUTIONS.md
@@ -1,0 +1,119 @@
+# Contributing to Upstream
+
+This fork (`Troubladore/mcp-atlassian`) maintains alignment with `sooperset/mcp-atlassian` and contributes features back when they're generally useful.
+
+## Architecture: Clean Rebase Stack
+
+Our `eruditis/main` branch is a clean rebase on top of upstream `main`. Every fork-specific commit sits on top of the latest upstream, making it easy to see exactly what's different and to drop commits as upstream adopts features.
+
+```
+upstream/main ─── A ─── B ─── C               (upstream)
+                                 \
+eruditis/main                     D ─── E ─── F  (fork-only commits)
+```
+
+When upstream moves forward, we rebase:
+
+```bash
+git checkout main && git pull upstream main && git push origin main
+git checkout eruditis/main && git rebase main
+# resolve any conflicts
+git push --force-with-lease origin eruditis/main
+```
+
+When upstream merges one of our PRs, that commit drops out of the rebase naturally.
+
+## How to Propose Features Upstream
+
+### 1. Create a focused branch from `main`
+
+Each upstream PR should contain exactly one feature, branched from `main` (the upstream mirror), not from `eruditis/main`.
+
+```bash
+git checkout main
+git checkout -b feature/my-feature   # or fix/my-fix
+```
+
+### 2. Implement the feature cleanly
+
+- No fork-specific code (no MCPB, no fork CI, no Claude rules)
+- Follow upstream conventions: Google docstrings, ruff 88-char, mypy
+- Run `uv run pytest tests/ -x` and `uv run pre-commit run --all-files`
+
+### 3. Switch to the classic PAT for cross-repo operations
+
+The fine-grained PAT (`github_pat_...`) is scoped to our fork only. To create PRs or issues on `sooperset/mcp-atlassian`, switch to the classic token:
+
+```bash
+# Switch auth context
+gh auth login
+# Select: GitHub.com → Paste token → paste the classic token (ghp_...)
+
+# Verify
+gh auth status   # Should show ghp_... token
+```
+
+The classic PAT needs only the `public_repo` scope. Generate one at:
+https://github.com/settings/tokens/new (select "Generate new token (classic)")
+
+### 4. Create an issue first (for features)
+
+Bug fixes can go straight to a PR. Features should have an issue first:
+
+```bash
+gh issue create \
+  --repo sooperset/mcp-atlassian \
+  --title "[Feature]: Description of the feature" \
+  --body "..."
+```
+
+### 5. Push and create the PR
+
+```bash
+git push -u origin feature/my-feature
+
+gh api repos/sooperset/mcp-atlassian/pulls \
+  --method POST \
+  -f title="feat(scope): description" \
+  -f head="Troubladore:feature/my-feature" \
+  -f base="main" \
+  -f body="PR body here..."
+```
+
+### 6. Switch back to fine-grained PAT for fork work
+
+```bash
+gh auth login
+# Paste the fine-grained token (github_pat_...)
+```
+
+## Active Upstream PRs
+
+Tracked in [Issue #28](https://github.com/Troubladore/mcp-atlassian/issues/28).
+
+| Upstream PR | Feature | Branch |
+|-------------|---------|--------|
+| [#1087](https://github.com/sooperset/mcp-atlassian/pull/1087) | Security: `endswith()` URL validation | `fix/url-validation-bypass` |
+| [#1088](https://github.com/sooperset/mcp-atlassian/pull/1088) | `ALLOW_DELETE_TOOLS` safety filter | `feature/delete-tools-safety-filter` |
+| [#1090](https://github.com/sooperset/mcp-atlassian/pull/1090) | `get_space_page_tree` hierarchy tool | `feature/space-page-tree` |
+| [#1091](https://github.com/sooperset/mcp-atlassian/pull/1091) | Page width layout support | `feature/page-width-support` |
+| [#1092](https://github.com/sooperset/mcp-atlassian/pull/1092) | Error recovery / fuzzy matching | `feature/intelligent-error-recovery` |
+
+## When Upstream Merges a PR
+
+1. Sync `main`: `git checkout main && git pull upstream main && git push origin main`
+2. Rebase fork: `git checkout eruditis/main && git rebase main`
+3. The merged feature's fork commit will conflict — resolve by accepting upstream's version (it's now the same code)
+4. Delete the feature branch: `git branch -D feature/xxx && git push origin --delete feature/xxx`
+5. Update issue #28 status
+6. Force push: `git push --force-with-lease origin eruditis/main`
+
+## Monitoring
+
+```bash
+# Check all upstream PR statuses
+for pr in 1087 1088 1090 1091 1092; do
+  echo -n "sooperset#$pr: "
+  gh pr view $pr --repo sooperset/mcp-atlassian --json state,title -q '"\(.state) - \(.title)"'
+done
+```


### PR DESCRIPTION
## Summary
- New `docs/UPSTREAM_CONTRIBUTIONS.md` documenting the full workflow: rebase strategy, how to propose features upstream, auth context switching (fine-grained vs classic PAT), monitoring active PRs, and handling upstream merges
- Updated `CLAUDE.md` with upstream alignment quick reference and auth context note
- Updated `.claude/rules/upstream-merge.md` with rebase (not merge) process and current fork feature list

References #28

## Test plan
- [x] Pre-commit clean
- [x] Documentation only — no code changes