### PR TITLE
chore: enforce branch+PR workflow for all changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ This is a fork of `sooperset/mcp-atlassian`. Remotes:
 - `origin` = `Troubladore/mcp-atlassian` (our fork)
 - `upstream` = `sooperset/mcp-atlassian` (upstream)
 
-Our development branch is `eruditis/main`. Feature branches merge into `eruditis/main` via PR. The `main` branch is a clean mirror of upstream.
+Our development branch is `eruditis/main`. The `main` branch is a clean mirror of upstream.
+
+**NEVER commit directly to `eruditis/main` or `main`.** Always create a feature branch and merge via PR — no exceptions, even for "quick" changes like version bumps or doc fixes.
 
 ## Developer Setup
 


### PR DESCRIPTION
## Summary
- Make the no-direct-push rule prominent in CLAUDE.md with bold text
- Explicitly states: no exceptions, even for version bumps or doc fixes

## Context
We pushed several chore commits directly to `eruditis/main` today instead of using branches+PRs. This makes the rule unmissable so it doesn't happen again.

## Test plan
- [x] Documentation only — no code changes