### PR TITLE
feat: add upstream discussions engagement skill

### DIFF
--- a/.claude/skills/upstream-discussions/skill.md
+++ b/.claude/skills/upstream-discussions/skill.md
@@ -171,6 +171,10 @@ Use when the discussion already has a correct answer but isn't marked resolved.
 
 ## Post Response
 
+**Auth requirement:** Posting to upstream discussions requires the classic PAT
+(`ghp_`), not the fine-grained PAT (`github_pat_`). Check with `gh auth status`
+and switch if needed: `gh auth login` (select github.com, paste classic token).
+
 Get the discussion's GraphQL node ID first (from the fetch query), then post:
 
 ```bash
@@ -227,6 +231,9 @@ Commit log updates to the feature branch periodically.
 ## Tone Guidelines
 
 - **Factual and concise** — no filler, no "Happy to help!"
+- **Non-confrontational** — never make the asker feel dumb. Soften references to
+  docs/tests: "this test actually covers the pattern you asked about" not "this
+  exact pattern is covered by the test suite." The goal is to help, not lecture.
 - **Link rather than duplicate** — point to PRs, issues, docs
 - **Represent the project** — we're community members helping, not authorities
 - **No performative enthusiasm** — state facts, provide links

--- a/.claude/skills/upstream-discussions/skill.md
+++ b/.claude/skills/upstream-discussions/skill.md
@@ -1,0 +1,262 @@
+---
+name: upstream-discussions
+description: Use when responding to upstream sooperset/mcp-atlassian GitHub Discussions. Provides the workflow for cross-referencing resolved issues/PRs, drafting targeted responses, and tracking engagement.
+---
+
+# Upstream Discussions Engagement
+
+## Quick Start
+
+1. Read the tracking log: `docs/upstream-discussions-log.md`
+2. Fetch open discussions (see Fetch step below)
+3. For each discussion (oldest first):
+   a. Cross-reference against triage log, closed issues, and codebase
+   b. **Find or write evidence** (test, PR, codebase citation) — BEFORE drafting
+   c. If evidence exists: run/verify it, then draft response citing it
+   d. If no evidence: skip or defer — never draft without proof
+   e. Present to user for review
+   f. Post if approved, log either way
+4. Commit log updates
+
+**This is TDD for Discussions.** Evidence first, response second. Always.
+
+## Scope
+
+**Respond to (concrete resolutions + light guidance):**
+- Q&A where a resolved triage issue or merged PR answers the question
+- Questions answerable from codebase knowledge (existing tools, configuration)
+- General questions where we can point to specific functionality
+
+**Skip:**
+- Discussions already answered satisfactorily
+- Feature debates or opinion-based discussions
+- Announcements, polls, show-and-tell
+- Discussions where we'd just be guessing
+- Anything we cannot back with evidence (test, PR, or codebase citation)
+
+## Fetch Discussions
+
+```bash
+gh api graphql -f query='{ repository(owner: "sooperset", name: "mcp-atlassian") {
+  discussions(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) {
+    nodes { number title body category { name } comments { totalCount }
+      createdAt answer { id } labels(first:5) { nodes { name } } }
+  }
+} }'
+```
+
+To read a specific discussion's full body and comments:
+```bash
+gh api graphql -f query='{ repository(owner: "sooperset", name: "mcp-atlassian") {
+  discussion(number: NNN) {
+    id number title body category { name }
+    comments(first: 20) { nodes { body author { login } createdAt } }
+  }
+} }'
+```
+
+## Cross-Reference Sources
+
+Check these in order to find matches:
+
+1. **Triage log** — `docs/upstream-triage-log.md` for RESOLVED issues with PR links
+2. **Discussions log** — `docs/upstream-discussions-log.md` for already-handled (skip)
+3. **Closed issues** — `gh issue list --repo sooperset/mcp-atlassian --state closed --limit 100`
+4. **Codebase search** — grep `src/mcp_atlassian/` for relevant tools, methods, config
+5. **Test search** — grep `tests/` for existing tests that prove the behavior
+
+
+## Per-Discussion Workflow (TDD for Discussions)
+
+### Step 1: Read & Cross-Reference
+
+Read the full discussion + comments. Cross-reference against triage log, closed
+issues, and codebase. Identify what the user is asking about.
+
+### Step 2: Find or Build Evidence (BEFORE drafting)
+
+This is the RED/GREEN step. Before writing a single word of response:
+
+1. **Search for existing tests** that prove the behavior:
+   ```bash
+   grep -r "relevant_keyword" tests/
+   ```
+2. **If test exists** — run it. Confirm it passes (GREEN). This is your evidence.
+3. **If no test exists but one is warranted** — write a unit test that demonstrates
+   the correct behavior. Run it. Watch it pass. Commit it to the branch.
+4. **If a merged PR covers it** — the PR's test evidence is sufficient. Cite it.
+5. **If only codebase reading confirms it** (config/setup questions) — cite file:line.
+6. **If you cannot establish evidence** — SKIP or DEFER. Do not draft.
+
+**The evidence step is not optional.** A response without evidence is a guess.
+Guesses posted to a community forum damage trust.
+
+### Step 3: Present to User (evidence + draft)
+
+Only after evidence is established, present:
+
+```
+─── Discussion #NNN: "Title" (Category) ───
+Created: YYYY-MM-DD | Comments: N | Answered: yes/no
+URL: https://github.com/sooperset/mcp-atlassian/discussions/NNN
+
+Body (first 500 chars):
+> [excerpt]
+
+Existing comments summary:
+> [key points from thread]
+
+Cross-reference:
+> Matches triage issue #NNN (RESOLVED, PR #NNNN)
+> — or —
+> Codebase: `tool_name` in src/mcp_atlassian/servers/jira.py handles this
+
+Evidence (REQUIRED):
+> GREEN: tests/unit/.../test_file.py::test_name passes — proves correct usage
+> — or —
+> GREEN: PR #NNNN merged with test coverage
+> — or —
+> NEW TEST: wrote tests/unit/.../test_file.py::test_name — passes, committed
+> — or —
+> CITE: src/mcp_atlassian/config.py:42 shows the configuration option
+
+Draft response:
+> [generated using appropriate template, citing the evidence]
+
+Action: [Approve] [Edit] [Skip] [Defer]
+```
+
+Always use AskUserQuestion for the action — never post without explicit approval.
+
+## Response Templates
+
+### Pattern A — Resolved by PR
+
+Use when a triage issue maps directly to the discussion topic.
+
+```
+This was addressed in PR #NNNN ([brief title]). [One sentence on what changed].
+
+If you're on the latest version, [tool/feature] should work as expected. See
+the PR for details: https://github.com/sooperset/mcp-atlassian/pull/NNNN
+```
+
+### Pattern B — Existing Functionality (Guidance)
+
+Use when the answer is already in the codebase but the user may not know.
+
+```
+The `tool_name` tool handles this. [1-2 sentences explaining usage or config].
+
+For reference, [link to relevant file or docs section if available].
+```
+
+### Pattern C — Redirect to Issue
+
+Use when the discussion describes a real bug or feature request that should be tracked.
+
+```
+This sounds like it would be best tracked as [a bug report / feature request].
+Would you mind opening an issue? That way it can be prioritized and tracked
+properly.
+```
+
+### Pattern D — Already Resolved in Thread
+
+Use when the discussion already has a correct answer but isn't marked resolved.
+
+```
+[Skip — no response needed, but log as SKIPPED with reason "already answered"]
+```
+
+## Post Response
+
+Get the discussion's GraphQL node ID first (from the fetch query), then post:
+
+```bash
+gh api graphql -f query='mutation {
+  addDiscussionComment(input: {
+    discussionId: "DISCUSSION_NODE_ID",
+    body: "RESPONSE_TEXT"
+  }) {
+    comment { id url }
+  }
+}'
+```
+
+**Important:** Escape the response body properly for JSON. Use a variable:
+
+```bash
+BODY='The response text here'
+gh api graphql -f query="mutation { addDiscussionComment(input: { discussionId: \"NODE_ID\", body: \"$BODY\" }) { comment { id url } } }"
+```
+
+Or better, use the `-f` flag for variables:
+
+```bash
+gh api graphql \
+  -f query='mutation($discussionId: ID!, $body: String!) {
+    addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+      comment { id url }
+    }
+  }' \
+  -f discussionId="NODE_ID" \
+  -f body="Response text here"
+```
+
+## Log Updates
+
+After each discussion is handled, update `docs/upstream-discussions-log.md`:
+
+```markdown
+| Discussion # | Title | Category | Status | Date | Action | Linked To |
+|---|---|---|---|---|---|---|
+| NNN | Title | Q&A | RESPONDED | 2026-03-03 | Linked PR | PR #NNNN |
+| NNN | Title | General | SKIPPED | 2026-03-03 | Already answered | — |
+| NNN | Title | Q&A | DEFERRED | 2026-03-03 | Needs research | — |
+```
+
+**Status values:**
+- RESPONDED — we posted a reply
+- SKIPPED — no action needed (already answered, off-topic, etc.)
+- DEFERRED — needs more research before responding
+- PENDING — not yet examined
+
+Commit log updates to the feature branch periodically.
+
+## Tone Guidelines
+
+- **Factual and concise** — no filler, no "Happy to help!"
+- **Link rather than duplicate** — point to PRs, issues, docs
+- **Represent the project** — we're community members helping, not authorities
+- **No performative enthusiasm** — state facts, provide links
+- **Respect existing answers** — if someone already answered well, skip or upvote
+- **One discussion at a time** — never batch-post responses
+
+## Comment Etiquette
+
+- Read the full thread before drafting — don't repeat what others said
+- If the discussion author already found a workaround, acknowledge it
+- Never promise features or timelines
+- If unsure, skip — a wrong answer is worse than no answer
+- Always defer to the maintainer's existing responses — if they already answered well, skip
+- For Q&A category: only the discussion author or repo maintainers can mark a comment
+  as "the answer." We cannot do this ourselves (requires write permissions). If a
+  maintainer has already given a correct response that isn't marked as answered, that's
+  their call to make — do not nag about it
+
+## Session Flow
+
+A typical session looks like:
+
+1. Invoke this skill
+2. Fetch discussions + read logs
+3. Filter to unhandled discussions
+4. For each (oldest first):
+   a. Read full discussion + comments
+   b. Cross-reference against triage log and codebase
+   c. Present to user with draft
+   d. User approves/edits/skips/defers
+   e. Post if approved, log either way
+5. Commit log updates
+6. Report summary (responded: N, skipped: N, deferred: N)

--- a/docs/plans/2026-03-03-upstream-discussions-design.md
+++ b/docs/plans/2026-03-03-upstream-discussions-design.md
@@ -1,0 +1,114 @@
+# Upstream Discussions Engagement — Design
+
+**Date:** 2026-03-03
+**Status:** Approved
+
+## Goal
+
+Build a skill for engaging with GitHub Discussions on `sooperset/mcp-atlassian`.
+The skill cross-references resolved issues/PRs from our triage work and provides
+targeted, thoughtful responses to community questions — one discussion at a time,
+with human approval before posting.
+
+## Scope
+
+- **In scope:** Q&A discussions where we can link resolved issues/PRs, and
+  general guidance questions answerable from codebase knowledge.
+- **Out of scope:** Opinionated feature debates, announcements, polls.
+- **Response style:** Short + links (2-4 sentences, link to PR/issue, let the
+  PR do the heavy lifting).
+
+## Skill Location
+
+`.claude/skills/upstream-discussions/skill.md`
+
+## Core Principle: TDD for Discussions
+
+**Evidence first, response second.** Before drafting any response, find or write
+a test that proves the behavior we'd be advising. This is Red/Green TDD applied
+to community engagement — we never guess, we prove.
+
+Evidence hierarchy:
+1. Existing test proves it (strongest — cite test file + function)
+2. Merged PR proves it (cite PR, its tests back the claim)
+3. Write a new test (run it, commit it, cite the output)
+4. Codebase reading confirms it (config/setup only — cite file:line)
+5. Cannot prove it — skip or defer, never draft
+
+## Workflow
+
+### 1. Fetch
+
+Pull all open discussions via GraphQL:
+
+```bash
+gh api graphql -f query='{ repository(owner: "sooperset", name: "mcp-atlassian") {
+  discussions(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) {
+    nodes { number title body category { name } comments { totalCount }
+      createdAt answer { id } labels(first:5) { nodes { name } } }
+  }
+} }'
+```
+
+### 2. Cross-Reference
+
+Match discussions against:
+1. `docs/upstream-triage-log.md` — RESOLVED issues with PR links
+2. `docs/upstream-discussions-log.md` — already-handled discussions (skip)
+3. Closed issues via `gh issue list --state closed`
+4. Codebase search for guidance questions
+
+### 3. Present (One at a Time)
+
+For each unhandled discussion, present:
+- Discussion title, category, body excerpt, comment count
+- Cross-reference matches (triage issues, PRs, codebase hits)
+- Draft response using the appropriate template
+
+### 4. User Review
+
+Actions per discussion:
+- **Approve** — post draft as-is
+- **Edit** — user provides revised text
+- **Skip** — mark as skipped with reason
+- **Defer** — needs more research
+
+### 5. Post
+
+```bash
+gh api graphql -f query='mutation {
+  addDiscussionComment(input: {discussionId: "ID", body: "response"}) {
+    comment { id }
+  }
+}'
+```
+
+### 6. Log
+
+Track in `docs/upstream-discussions-log.md`:
+
+| Discussion # | Title | Category | Status | Date | Action | Linked To |
+|---|---|---|---|---|---|---|
+| 274 | Debugging guidance | Q&A | RESPONDED | 2026-03-03 | Linked PR | PR #1120 |
+
+Status values: RESPONDED, SKIPPED, DEFERRED, PENDING
+
+## Response Templates
+
+**Pattern A — Resolved by PR:**
+> This was addressed in PR #NNNN. [Brief explanation]. If you're on the latest
+> version, [tool/feature] should work as expected.
+
+**Pattern B — Existing functionality:**
+> The `tool_name` tool handles this. [1-2 sentences on usage].
+
+**Pattern C — Redirect:**
+> This would be best tracked as a feature request. Would you mind opening an
+> issue so it can be triaged?
+
+## Tone
+
+- Factual, concise, helpful
+- No performative enthusiasm
+- Link rather than duplicate
+- Represent the community, not ourselves

--- a/docs/upstream-discussions-log.md
+++ b/docs/upstream-discussions-log.md
@@ -1,0 +1,18 @@
+# Upstream Discussions Engagement Log
+
+Tracking document for community engagement on `sooperset/mcp-atlassian` GitHub Discussions.
+**Skill:** `.claude/skills/upstream-discussions/`
+
+## Status Key
+
+| Status | Meaning |
+|--------|---------|
+| PENDING | Not yet examined |
+| RESPONDED | Reply posted |
+| SKIPPED | No action needed (already answered, off-topic, etc.) |
+| DEFERRED | Needs more research before responding |
+
+## Discussions Log
+
+| Discussion # | Title | Category | Status | Date | Action | Linked To |
+|---|---|---|---|---|---|---|

--- a/docs/upstream-discussions-log.md
+++ b/docs/upstream-discussions-log.md
@@ -16,5 +16,33 @@ Tracking document for community engagement on `sooperset/mcp-atlassian` GitHub D
 
 | Discussion # | Title | Category | Status | Date | Action | Linked To |
 |---|---|---|---|---|---|---|
+| 264 | Welcome to Discussions! | Announcement | SKIPPED | 2026-03-03 | Announcement, not actionable | — |
+| 269 | MCP Simple Slackbot compatible? | Q&A | SKIPPED | 2026-03-03 | Maintainer answered | — |
 | 274 | Debugging guidance | Q&A | SKIPPED | 2026-03-03 | Maintainer answered | — |
-| 342 | Cannot update a jira ticket | Q&A | DEFERRED | 2026-03-03 | Draft ready, blocked on auth (need classic PAT) | `test_update_issue_accepts_json_string_fields` |
+| 278 | Compact tools by type | Ideas | RESPONDED | 2026-03-03 | Toolsets feature exists | `tests/unit/utils/test_toolsets.py` |
+| 285 | Data visualization | Ideas | SKIPPED | 2026-03-03 | Out of scope, community answered | — |
+| 290 | Setting up MCP client for stdio | Q&A | SKIPPED | 2026-03-03 | Maintainer answered | — |
+| 300 | test_get_project_issues / Protocols | General | SKIPPED | 2026-03-03 | Internal dev discussion, maintainer engaged | — |
+| 303 | Excessive startup requests | General | SKIPPED | 2026-03-03 | Maintainer answered: fixed in v0.8.0 | — |
+| 317 | JIRA_SSL_Verify = False fails | Q&A | SKIPPED | 2026-03-03 | Maintainer answered: known #327, use uvx | — |
+| 329 | Librechat usage | General | SKIPPED | 2026-03-03 | Maintainer answered | — |
+| 334 | Cannot run Docker image | Q&A | SKIPPED | 2026-03-03 | Insufficient detail, commenter asked for info | — |
+| 337 | MCP Server returns empty tool list | Q&A | SKIPPED | 2026-03-03 | Already resolved | — |
+| 342 | Cannot update a jira ticket | Q&A | RESPONDED | 2026-03-03 | Guidance: fields must be JSON string | `test_update_issue_accepts_json_string_fields` |
+| 344 | Refactoring get_epic_issues / field_ids | General | SKIPPED | 2026-03-03 | Already resolved | — |
+| 348 | Server returns only Confluence tools | Q&A | SKIPPED | 2026-03-03 | Already resolved | — |
+| 349 | Not able to fetch jira_search result | Q&A | SKIPPED | 2026-03-03 | Maintainer answered | — |
+| 351 | Tool whitelist | Ideas | SKIPPED | 2026-03-03 | Maintainer answered: TOOLSETS in v0.9.0 | — |
+| 352 | How to configure SSE | Q&A | SKIPPED | 2026-03-03 | Self-resolved by user | — |
+| 364 | Integrating with local MCP client | Q&A | SKIPPED | 2026-03-03 | Maintainer answered | — |
+| 385 | Comparison with Atlassian's MCP | Q&A | SKIPPED | 2026-03-03 | Opinion-based, community answered | — |
+| 392 | executeTool format in n8n | Q&A | SKIPPED | 2026-03-03 | n8n-specific, no evidence possible | — |
+| 393 | Example prompt from demo video | Q&A | SKIPPED | 2026-03-03 | About demo video, no evidence possible | — |
+| 403 | GitHub Copilot / VS Code integration | General | SKIPPED | 2026-03-03 | Community answered | — |
+| 418 | Security awareness | Q&A | SKIPPED | 2026-03-03 | Maintainer answered | — |
+| 425 | Integrate tools with LLM agent | General | SKIPPED | 2026-03-03 | Insufficient detail, no evidence possible | — |
+| 427 | Can't get mcp-atlassian to work with Cline | Q&A | SKIPPED | 2026-03-03 | Docker/WSL env propagation issue, no evidence | — |
+| 437 | Confluence error | General | SKIPPED | 2026-03-03 | Already resolved | — |
+| 444 | Not listening on any port | Q&A | SKIPPED | 2026-03-03 | Docker/infra issue (#420) | — |
+| 462 | Context window issues | General | RESPONDED | 2026-03-03 | Guidance: fields, limit, TOOLSETS | `test_search` |
+| 464 | Bitbucket inclusion | Ideas | SKIPPED | 2026-03-03 | Out of scope | — |

--- a/docs/upstream-discussions-log.md
+++ b/docs/upstream-discussions-log.md
@@ -16,3 +16,5 @@ Tracking document for community engagement on `sooperset/mcp-atlassian` GitHub D
 
 | Discussion # | Title | Category | Status | Date | Action | Linked To |
 |---|---|---|---|---|---|---|
+| 274 | Debugging guidance | Q&A | SKIPPED | 2026-03-03 | Maintainer answered | — |
+| 342 | Cannot update a jira ticket | Q&A | DEFERRED | 2026-03-03 | Draft ready, blocked on auth (need classic PAT) | `test_update_issue_accepts_json_string_fields` |


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/upstream-discussions/skill.md` — workflow for engaging with upstream GitHub Discussions
- Core principle: **TDD for Discussions** — find or write test evidence before drafting any community response
- Reviewed all 30 open discussions: 3 responded (with test evidence), 27 skipped (maintainer answered, out of scope, etc.)
- Includes design doc, tracking log, and tone guidelines refined from live testing

## What was posted
- #278 (Compact tools by type) — pointed to TOOLSETS feature, cited 34 passing tests
- #342 (Cannot update a jira ticket) — explained JSON string format, cited regression test
- #462 (Context window issues) — explained fields/limit/pagination, cited search test

## Test plan
- [x] Skill tested on real discussions before finalizing
- [x] All cited tests run and confirmed GREEN before posting
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)