### PR TITLE
feat(docker): add Claude Code launcher with Docker pre-flight checks

### DIFF
--- a/docs/mcpb-extension/README.md
+++ b/docs/mcpb-extension/README.md
@@ -1,6 +1,8 @@
-# Eruditis Atlassian Extension for Claude Desktop
+# Eruditis Atlassian MCP Server
 
 Connect Claude to Eruditis Confluence and Jira via the [mcp-atlassian](https://github.com/sooperset/mcp-atlassian) MCP server running in a sandboxed Docker container.
+
+Supports both **Claude Code (CLI)** and **Claude Desktop** with the same security model: container isolation, network egress filtering, and least-privilege defaults.
 
 ## Features
 
@@ -9,23 +11,86 @@ Connect Claude to Eruditis Confluence and Jira via the [mcp-atlassian](https://g
 - **Read-only by default**: Write operations must be explicitly enabled
 - **Configurable toolsets**: Control which tool categories are available via TOOLSETS
 - **Delete protection**: Delete operations blocked by default, even when writes are enabled
-- **Encrypted credentials**: API tokens stored in OS keychain (macOS Keychain or Windows Credential Manager)
 - **Automatic setup**: Filtering proxy auto-starts on first use, no manual configuration needed
 
-## Prerequisites
+## Prerequisites (Both Clients)
 
-- **Docker Desktop** must be installed and running on your machine
+- **Docker Desktop** must be installed and **running**
   - macOS/Windows: [Download Docker Desktop](https://docker.com/products/docker-desktop)
   - Linux/WSL2: Docker Engine with Docker CLI
-- **Node.js 18+** installed on your system (`node --version` to check)
-  - Download from [nodejs.org](https://nodejs.org)
-- **Claude Desktop** (latest version)
-  - Download from [claude.ai/download](https://claude.ai/download)
-- **Disable "Use built-in Node.js for MCP"** in Claude Desktop settings
-  - Go to **Settings > Extensions** and toggle off "Use built-in Node.js for MCP"
-  - See [Known Issue](#known-issue-built-in-nodejs) below for details
+  - WSL2 users: Enable WSL integration in Docker Desktop > Settings > Resources > WSL integration
+- **Atlassian API Token**: Generate at [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
 
-## Installation
+---
+
+## Claude Code (CLI) Setup
+
+The launcher script (`claude-code-launcher.sh`) manages the Docker containers directly via shell — no Node.js required.
+
+### Step 1: Create Credentials File
+
+```bash
+mkdir -p ~/.config/mcp-atlassian
+cat > ~/.config/mcp-atlassian/.env << 'EOF'
+ATLASSIAN_URL=https://your-instance.atlassian.net
+ATLASSIAN_EMAIL=your.email@example.com
+ATLASSIAN_API_TOKEN=your_api_token
+TOOLSETS=all
+READ_ONLY_MODE=false
+ALLOW_DELETE_TOOLS=false
+EOF
+chmod 600 ~/.config/mcp-atlassian/.env
+```
+
+### Step 2: Register the MCP Server
+
+```bash
+claude mcp add --scope user atlassian -- /path/to/docs/mcpb-extension/claude-code-launcher.sh
+```
+
+This adds the server to `~/.claude.json` at user scope (available in all projects).
+
+### Step 3: Pull the Docker Image
+
+```bash
+docker pull ghcr.io/troubladore/mcp-atlassian:v0.11.16
+```
+
+### Step 4: Verify
+
+Start a new Claude Code session (or run `/mcp` to reconnect), then ask Claude to list your Jira projects or search Confluence.
+
+### Troubleshooting (Claude Code)
+
+The launcher script performs pre-flight checks and prints diagnostics to stderr. If tools don't appear:
+
+```bash
+# 1. Is Docker running?
+docker info >/dev/null 2>&1 && echo "OK" || echo "FAIL: Start Docker Desktop"
+
+# 2. Run the launcher manually to see errors
+timeout 10 bash /path/to/claude-code-launcher.sh 2>&1
+
+# 3. Is the proxy healthy?
+docker ps --filter name=eruditis-atlassian-proxy
+
+# 4. Reconnect without restarting Claude Code
+# Type /mcp in your session
+```
+
+**Common issue on WSL2**: Docker Desktop must be running on the Windows host. If it's not, the `docker` command resolves (symlink exists) but execution fails silently. The launcher script detects this and prints a clear error.
+
+---
+
+## Claude Desktop Setup
+
+The `.mcpb` extension bundles a Node.js wrapper that manages Docker containers.
+
+### Additional Prerequisites
+
+- **Node.js 18+** installed on your system (`node --version` to check)
+- **Disable "Use built-in Node.js for MCP"** in Claude Desktop settings
+  - See [Known Issue](#known-issue-built-in-nodejs) below
 
 ### Step 1: Generate an Atlassian API Token
 
@@ -33,7 +98,18 @@ Connect Claude to Eruditis Confluence and Jira via the [mcp-atlassian](https://g
 2. Click "Create API token"
 3. Name it "Claude MCP" and copy the token (you'll need it in the next step)
 
-### Step 2: Pull the Docker Image (First Time Only)
+### Step 2: Install the Extension
+
+1. Open Claude Desktop
+2. Go to **Settings > Extensions**
+3. Find "Eruditis Atlassian" and click **Install** (or double-click the `.mcpb` file if shared directly)
+4. Fill in the configuration dialog:
+   - **Atlassian Site URL**: `https://eruditis.atlassian.net`
+   - **Atlassian Email**: Your email address used for Atlassian
+   - **API Token**: Paste the token from Step 1
+   - **Enable Write Operations**: Leave as `false` (read-only mode)
+
+### Step 3: Pull the Docker Image (First Time Only)
 
 Open a terminal and run:
 
@@ -42,17 +118,6 @@ docker pull ghcr.io/troubladore/mcp-atlassian:v0.11.10
 ```
 
 This ensures the Docker image is available before you try to use the extension.
-
-### Step 3: Install the Extension
-
-1. Open Claude Desktop
-2. Go to **Settings > Extensions**
-3. Find "Eruditis Atlassian" and click **Install** (or double-click the `.mcpb` file if shared directly)
-4. Fill in the configuration dialog:
-   - **Atlassian Site URL**: `https://eruditis.atlassian.net`
-   - **Atlassian Email**: Your Gmail address used for Atlassian
-   - **API Token**: Paste the token from Step 1
-   - **Enable Write Operations**: Leave as `false` (read-only mode)
 
 ### Step 4: Test It
 
@@ -68,7 +133,9 @@ or
 Show me the open Jira issues in the DEV project
 ```
 
-## Configuration Options
+---
+
+## Configuration Options (Both Clients)
 
 ### Toolsets
 
@@ -132,7 +199,8 @@ The extension automatically manages a filtering HTTP proxy that allows connectio
 
 ### Credential Security
 
-- **Encrypted storage**: API tokens stored in OS keychain (macOS Keychain or Windows Credential Manager)
+- **Claude Desktop**: API tokens stored in OS keychain (macOS Keychain or Windows Credential Manager)
+- **Claude Code**: API tokens stored in `~/.config/mcp-atlassian/.env` (chmod 600)
 - **Never logged**: Credentials masked in all log output
 - **Minimal exposure**: Only passed via environment variables to container
 

--- a/docs/mcpb-extension/claude-code-launcher.sh
+++ b/docs/mcpb-extension/claude-code-launcher.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Claude Code launcher for mcp-atlassian in a sandboxed Docker container
+# with network egress filtering via Squid proxy.
+#
+# Full parity with the Claude Desktop MCPB extension security model:
+#   - Container isolation (cap-drop=ALL, read-only, no-new-privileges)
+#   - Network egress filtering (only *.atlassian.net, *.jira.com, *.atlassian.com)
+#   - Resource limits (256MB memory, 0.5 CPU)
+#   - No host filesystem access
+#
+# Usage:
+#   claude mcp add --scope user atlassian -- /path/to/claude-code-launcher.sh
+#
+# Prerequisites:
+#   - Docker installed and running
+#   - ~/.config/mcp-atlassian/.env with credentials (see below)
+#   - Proxy image built (auto-builds on first run)
+#
+# .env file format:
+#   ATLASSIAN_URL=https://your-instance.atlassian.net
+#   ATLASSIAN_EMAIL=your.email@example.com
+#   ATLASSIAN_API_TOKEN=your_api_token
+#   TOOLSETS=all
+#   READ_ONLY_MODE=false
+#   ALLOW_DELETE_TOOLS=false
+
+set -euo pipefail
+
+# --- Configuration ---
+IMAGE="ghcr.io/troubladore/mcp-atlassian:v0.11.16"
+PROXY_IMAGE="eruditis/atlassian-proxy:latest"
+PROXY_CONTAINER_NAME="eruditis-atlassian-proxy"
+NETWORK_NAME="eruditis-atlassian-net"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${HOME}/.config/mcp-atlassian/.env"
+
+# --- Logging (to stderr so it doesn't interfere with MCP stdio) ---
+log() { echo "[eruditis-atlassian] $*" >&2; }
+
+# --- Verify Docker is available ---
+if ! command -v docker >/dev/null 2>&1; then
+  log "ERROR: 'docker' not found on PATH."
+  log "  If using WSL, ensure Docker Desktop is running and WSL integration is enabled."
+  log "  Docker Desktop → Settings → Resources → WSL integration → enable this distro."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  log "ERROR: Docker daemon is not running."
+  log "  Start Docker Desktop and wait for it to be ready."
+  exit 1
+fi
+
+# --- Load credentials ---
+if [[ ! -f "$ENV_FILE" ]]; then
+  log "ERROR: Credential file not found: $ENV_FILE"
+  log ""
+  log "Create it with:"
+  log "  mkdir -p ~/.config/mcp-atlassian"
+  log "  cat > ~/.config/mcp-atlassian/.env << 'EOF'"
+  log "ATLASSIAN_URL=https://your-instance.atlassian.net"
+  log "ATLASSIAN_EMAIL=your.email@example.com"
+  log "ATLASSIAN_API_TOKEN=your_api_token"
+  log "TOOLSETS=all"
+  log "READ_ONLY_MODE=false"
+  log "ALLOW_DELETE_TOOLS=false"
+  log "EOF"
+  log "  chmod 600 ~/.config/mcp-atlassian/.env"
+  exit 1
+fi
+
+# Source the env file
+set -a
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +a
+
+# Validate required vars
+if [[ -z "${ATLASSIAN_URL:-}" || -z "${ATLASSIAN_EMAIL:-}" || -z "${ATLASSIAN_API_TOKEN:-}" ]]; then
+  log "ERROR: Missing required config in $ENV_FILE"
+  log "  ATLASSIAN_URL: ${ATLASSIAN_URL:+set}"
+  log "  ATLASSIAN_EMAIL: ${ATLASSIAN_EMAIL:+set}"
+  log "  ATLASSIAN_API_TOKEN: ${ATLASSIAN_API_TOKEN:+set}"
+  exit 1
+fi
+
+# Defaults
+TOOLSETS="${TOOLSETS:-all}"
+READ_ONLY_MODE="${READ_ONLY_MODE:-false}"
+ALLOW_DELETE_TOOLS="${ALLOW_DELETE_TOOLS:-false}"
+CONFLUENCE_SPACES_FILTER="${CONFLUENCE_SPACES_FILTER:-}"
+JIRA_PROJECTS_FILTER="${JIRA_PROJECTS_FILTER:-}"
+
+# Normalize URLs
+BASE_URL="${ATLASSIAN_URL%/}"
+if [[ "$BASE_URL" == *"/wiki" ]]; then
+  CONFLUENCE_URL="$BASE_URL"
+  JIRA_URL="${BASE_URL%/wiki}"
+else
+  CONFLUENCE_URL="${BASE_URL}/wiki"
+  JIRA_URL="$BASE_URL"
+fi
+
+# --- Ensure Docker network exists ---
+if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  log "Creating Docker network: $NETWORK_NAME"
+  docker network create "$NETWORK_NAME" >/dev/null
+fi
+
+# --- Ensure proxy image is built ---
+if ! docker image inspect "$PROXY_IMAGE" >/dev/null 2>&1; then
+  log "Building Atlassian filtering proxy image..."
+  docker build -t "$PROXY_IMAGE" "${SCRIPT_DIR}/proxy" >&2
+fi
+
+# --- Ensure proxy container is running ---
+if ! docker ps --filter "name=${PROXY_CONTAINER_NAME}" --filter "status=running" --format "{{.Names}}" | grep -q "^${PROXY_CONTAINER_NAME}$"; then
+  # Remove stale container if it exists
+  docker rm -f "$PROXY_CONTAINER_NAME" 2>/dev/null || true
+
+  log "Starting Atlassian filtering proxy..."
+  docker run -d \
+    --name "$PROXY_CONTAINER_NAME" \
+    --restart=unless-stopped \
+    --network="$NETWORK_NAME" \
+    --cap-drop=ALL \
+    --security-opt no-new-privileges:true \
+    --read-only \
+    --tmpfs /var/cache/squid:noexec,nosuid,size=64m,uid=31,gid=31 \
+    --tmpfs /var/log/squid:noexec,nosuid,size=16m,uid=31,gid=31 \
+    --tmpfs /var/run/squid:noexec,nosuid,size=8m,uid=31,gid=31 \
+    "$PROXY_IMAGE" >/dev/null
+
+  # Wait for proxy to be ready
+  for i in $(seq 1 10); do
+    if docker exec "$PROXY_CONTAINER_NAME" nc -z 127.0.0.1 3128 2>/dev/null; then
+      log "Proxy ready."
+      break
+    fi
+    sleep 0.5
+  done
+else
+  log "Proxy already running."
+fi
+
+# --- Build Docker run args ---
+DOCKER_ARGS=(
+  run --rm -i
+  --network="$NETWORK_NAME"
+  --cap-drop=ALL
+  --security-opt no-new-privileges:true
+  --read-only
+  --tmpfs /tmp:noexec,nosuid,size=64m
+  --memory=256m
+  --cpus=0.5
+
+  # Credentials
+  -e "CONFLUENCE_URL=${CONFLUENCE_URL}"
+  -e "CONFLUENCE_USERNAME=${ATLASSIAN_EMAIL}"
+  -e "CONFLUENCE_API_TOKEN=${ATLASSIAN_API_TOKEN}"
+  -e "JIRA_URL=${JIRA_URL}"
+  -e "JIRA_USERNAME=${ATLASSIAN_EMAIL}"
+  -e "JIRA_API_TOKEN=${ATLASSIAN_API_TOKEN}"
+
+  # Tool config
+  -e "TOOLSETS=${TOOLSETS}"
+  -e "READ_ONLY_MODE=${READ_ONLY_MODE}"
+  -e "ALLOW_DELETE_TOOLS=${ALLOW_DELETE_TOOLS}"
+
+  # Network egress filtering
+  -e "HTTP_PROXY=http://${PROXY_CONTAINER_NAME}:3128"
+  -e "HTTPS_PROXY=http://${PROXY_CONTAINER_NAME}:3128"
+  -e "NO_PROXY=localhost,127.0.0.1"
+)
+
+# Optional filters
+[[ -n "$CONFLUENCE_SPACES_FILTER" ]] && DOCKER_ARGS+=(-e "CONFLUENCE_SPACES_FILTER=${CONFLUENCE_SPACES_FILTER}")
+[[ -n "$JIRA_PROJECTS_FILTER" ]] && DOCKER_ARGS+=(-e "JIRA_PROJECTS_FILTER=${JIRA_PROJECTS_FILTER}")
+
+# Image
+DOCKER_ARGS+=("$IMAGE")
+
+log "Launching MCP server (TOOLSETS=${TOOLSETS}, READ_ONLY=${READ_ONLY_MODE})..."
+
+# --- Run (stdin/stdout pass through for MCP stdio transport) ---
+exec docker "${DOCKER_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Add `claude-code-launcher.sh` for running the MCP server via Claude Code (CLI) with the same security model as the Desktop extension
- Add early Docker availability checks (`command -v docker` + `docker info`) with clear error messages — previously failures were completely silent
- Update README to document both Claude Code and Claude Desktop setup paths, including WSL2-specific troubleshooting

## Context
When Docker Desktop isn't running, the launcher script failed silently — Claude Code showed no error, tools just didn't appear. A person had no way to debug this without manually running the script. The pre-flight checks now fail fast with actionable messages.

## Test plan
- [x] Verified launcher fails with clear error when Docker is down
- [x] Verified MCP tools work end-to-end after Docker starts (Jira + Confluence)
- [x] Verified container security posture (cap-drop=ALL, read-only, no-new-privileges, proxy healthy)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)