### PR TITLE
fix(confluence): add ancestors to expand params in get_page_content (closes #73)

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -63,7 +63,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = v2_adapter.get_page(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment,history",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
             else:
                 logger.debug(
@@ -72,7 +72,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = self.confluence.get_page_by_id(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment,history",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
 
             # Check if API returned an error string
@@ -1031,7 +1031,7 @@ class PagesMixin(ConfluenceClient):
                 page = v2_adapter.get_page_by_version(
                     page_id=page_id,
                     version=version,
-                    expand="body.storage,version,space,children.attachment,history",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
             else:
                 logger.debug(
@@ -1043,7 +1043,7 @@ class PagesMixin(ConfluenceClient):
                     page_id=page_id,
                     status="historical",
                     version=version,
-                    expand="body.storage,version,space,children.attachment,history",
+                    expand="body.storage,version,space,children.attachment,history,ancestors",
                 )
 
             if isinstance(page, str):

--- a/tests/e2e/cloud/test_confluence_cloud_operations.py
+++ b/tests/e2e/cloud/test_confluence_cloud_operations.py
@@ -172,3 +172,58 @@ class TestConfluenceDateMacro:
         assert "2026-02-04" in content or "Feb" in content or "February" in content, (
             f"Date macro value missing from content. Got: {content[:500]}"
         )
+
+
+class TestConfluencePageAncestors:
+    """get_page_content should populate the ancestors field.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/1131
+    Root cause: 'ancestors' not included in expand params in get_page_content().
+    """
+
+    def test_child_page_has_ancestors(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        parent = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Ancestor Parent {uid}",
+            body="<p>Parent page.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(parent.id)
+
+        child = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Ancestor Child {uid}",
+            body="<p>Child page.</p>",
+            is_markdown=False,
+            parent_id=parent.id,
+        )
+        resource_tracker.add_confluence_page(child.id)
+
+        fetched = confluence_fetcher.get_page_content(child.id)
+        assert len(fetched.ancestors) > 0, (
+            "ancestors is empty — 'ancestors' missing from expand params"
+        )
+        parent_ids = [a.get("id") for a in fetched.ancestors]
+        assert parent.id in parent_ids, (
+            f"parent {parent.id} not in ancestors: {parent_ids}"
+        )
+
+        # Verify to_simplified_dict() — this is what the MCP tool returns
+        simplified = fetched.to_simplified_dict()
+        assert "ancestors" in simplified, (
+            "ancestors missing from to_simplified_dict() output"
+        )
+        simplified_parent_ids = [a["id"] for a in simplified["ancestors"]]
+        assert parent.id in simplified_parent_ids, (
+            f"parent {parent.id} not in simplified ancestors: {simplified['ancestors']}"
+        )
+        # Each ancestor should have id and title
+        for ancestor in simplified["ancestors"]:
+            assert "id" in ancestor, f"ancestor missing 'id': {ancestor}"
+            assert "title" in ancestor, f"ancestor missing 'title': {ancestor}"

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -39,7 +39,7 @@ class TestPagesMixin:
         # Assert
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
             page_id=page_id,
-            expand="body.storage,version,space,children.attachment,history",
+            expand="body.storage,version,space,children.attachment,history,ancestors",
         )
 
         # Verify result structure
@@ -67,6 +67,42 @@ class TestPagesMixin:
         assert len(result.attachments) == 2
         assert result.attachments[0].id is not None
         assert result.attachments[1].id is not None
+
+    def test_get_page_content_includes_ancestors_in_response(self, pages_mixin):
+        """Ancestors in API response flow through to ConfluencePage model.
+
+        Regression for https://github.com/sooperset/mcp-atlassian/issues/1131
+        Verifies the full path: API response → model → to_simplified_dict().
+        """
+        # Arrange — build a page response with ancestors included
+        import copy
+
+        from tests.fixtures.confluence_mocks import MOCK_PAGE_RESPONSE
+
+        page_with_ancestors = copy.deepcopy(MOCK_PAGE_RESPONSE)
+        page_with_ancestors["ancestors"] = [
+            {"id": "111", "title": "Grandparent Page", "type": "page"},
+            {"id": "222", "title": "Parent Page", "type": "page"},
+        ]
+        pages_mixin.confluence.get_page_by_id.return_value = page_with_ancestors
+        pages_mixin.config.url = "https://example.atlassian.net/wiki"
+
+        # Act
+        result = pages_mixin.get_page_content("987654321", convert_to_markdown=True)
+
+        # Assert — ancestors populated on model
+        assert len(result.ancestors) == 2
+        assert result.ancestors[0]["id"] == "111"
+        assert result.ancestors[0]["title"] == "Grandparent Page"
+        assert result.ancestors[1]["id"] == "222"
+        assert result.ancestors[1]["title"] == "Parent Page"
+
+        # Assert — ancestors included in simplified dict (MCP tool output)
+        simplified = result.to_simplified_dict()
+        assert "ancestors" in simplified
+        assert len(simplified["ancestors"]) == 2
+        assert simplified["ancestors"][0] == {"id": "111", "title": "Grandparent Page"}
+        assert simplified["ancestors"][1] == {"id": "222", "title": "Parent Page"}
 
     def test_get_page_ancestors(self, pages_mixin):
         """Test getting page ancestors (parent pages)."""
@@ -700,7 +736,7 @@ class TestPagesMixin:
         # Verify the API call
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
             page_id=page_id,
-            expand="body.storage,version,space,children.attachment,history",
+            expand="body.storage,version,space,children.attachment,history,ancestors",
         )
 
         # Verify the result
@@ -1031,7 +1067,7 @@ class TestPagesMixin:
             page_id=page_id,
             status="historical",
             version=version,
-            expand="body.storage,version,space,children.attachment,history",
+            expand="body.storage,version,space,children.attachment,history,ancestors",
         )
 
         # Verify result is a ConfluencePage
@@ -1456,7 +1492,7 @@ class TestPagesOAuthMixin:
             # Assert that v2 API was used instead of v1
             mock_v2_adapter.get_page.assert_called_once_with(
                 page_id=page_id,
-                expand="body.storage,version,space,children.attachment,history",
+                expand="body.storage,version,space,children.attachment,history,ancestors",
             )
 
             # Verify v1 API was NOT called
@@ -1547,7 +1583,7 @@ class TestPagesOAuthMixin:
             mock_v2_adapter.get_page_by_version.assert_called_once_with(
                 page_id=page_id,
                 version=version,
-                expand="body.storage,version,space,children.attachment,history",
+                expand="body.storage,version,space,children.attachment,history,ancestors",
             )
 
             # Verify v1 API was NOT called


### PR DESCRIPTION
Integrates [upstream PR #1133](https://github.com/sooperset/mcp-atlassian/pull/1133) into community/main.