### PR TITLE
fix(confluence): add history to expand params in get_page_content (closes #34)

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -63,7 +63,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = v2_adapter.get_page(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
             else:
                 logger.debug(
@@ -72,7 +72,7 @@ class PagesMixin(ConfluenceClient):
                 )
                 page = self.confluence.get_page_by_id(
                     page_id=page_id,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
 
             # Check if API returned an error string
@@ -1031,7 +1031,7 @@ class PagesMixin(ConfluenceClient):
                 page = v2_adapter.get_page_by_version(
                     page_id=page_id,
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
             else:
                 logger.debug(
@@ -1043,7 +1043,7 @@ class PagesMixin(ConfluenceClient):
                     page_id=page_id,
                     status="historical",
                     version=version,
-                    expand="body.storage,version,space,children.attachment",
+                    expand="body.storage,version,space,children.attachment,history",
                 )
 
             if isinstance(page, str):

--- a/src/mcp_atlassian/models/confluence/page.py
+++ b/src/mcp_atlassian/models/confluence/page.py
@@ -200,6 +200,11 @@ class ConfluencePage(ApiModel, TimestampMixin):
             if not updated and version and version.when:
                 updated = version.when
 
+            # Fall back to history.createdBy if no top-level author
+            if not author:
+                if created_by := history.get("createdBy"):
+                    author = ConfluenceUser.from_api_response(created_by)
+
         # Construct URL if base_url is provided
         url = None
         if base_url := kwargs.get("base_url"):

--- a/tests/e2e/cloud/test_confluence_dates.py
+++ b/tests/e2e/cloud/test_confluence_dates.py
@@ -1,0 +1,60 @@
+"""E2E tests for Confluence page date fields (upstream #965)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluencePageDateFields:
+    """ConfluencePage.created and .updated fields are always empty.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/965
+    Same root cause as #607: 'history' not included in expand params.
+    Test FAILS until history is added to expand in pages.py.
+    """
+
+    def test_page_created_date_populated(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Date fields test {uid}",
+            body="<p>Testing date fields.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.created, (
+            "ConfluencePage.created is empty — 'history' missing from expand params"
+        )
+
+    def test_page_updated_date_populated(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Updated date test {uid}",
+            body="<p>Testing updated date field.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.updated, (
+            "ConfluencePage.updated is empty — 'history' missing from expand params"
+        )

--- a/tests/e2e/cloud/test_confluence_page_metadata.py
+++ b/tests/e2e/cloud/test_confluence_page_metadata.py
@@ -1,0 +1,74 @@
+"""E2E tests for Confluence page metadata fields (upstream #607)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from mcp_atlassian.confluence import ConfluenceFetcher
+
+from .conftest import CloudInstanceInfo, CloudResourceTracker
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestConfluencePageMetadata:
+    """Page metadata fields (created, updated, author) are populated.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/607
+    Root cause: get_page_content() missing 'history' in expand params.
+    Fix: add 'history' to expand string in pages.py lines 66 and 75.
+    Branch sits here until fix is implemented — test currently FAILS.
+    """
+
+    def test_page_has_created_date(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Metadata Test {uid}",
+            body="<p>Testing metadata retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.created, "created date is empty — 'history' missing from expand"
+
+    def test_page_has_last_modified(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Modified Test {uid}",
+            body="<p>Testing metadata retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.updated, "updated date is empty — 'history' missing from expand"
+
+    def test_page_has_author(
+        self,
+        confluence_fetcher: ConfluenceFetcher,
+        cloud_instance: CloudInstanceInfo,
+        resource_tracker: CloudResourceTracker,
+    ) -> None:
+        uid = uuid.uuid4().hex[:8]
+        page = confluence_fetcher.create_page(
+            space_key=cloud_instance.space_key,
+            title=f"Cloud E2E Author Test {uid}",
+            body="<p>Testing author retrieval.</p>",
+            is_markdown=False,
+        )
+        resource_tracker.add_confluence_page(page.id)
+        fetched = confluence_fetcher.get_page_content(page.id)
+        assert fetched.author is not None, "author is None — not returned by API"

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -38,7 +38,8 @@ class TestPagesMixin:
 
         # Assert
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,history",
         )
 
         # Verify result structure
@@ -698,7 +699,8 @@ class TestPagesMixin:
 
         # Verify the API call
         pages_mixin.confluence.get_page_by_id.assert_called_once_with(
-            page_id=page_id, expand="body.storage,version,space,children.attachment"
+            page_id=page_id,
+            expand="body.storage,version,space,children.attachment,history",
         )
 
         # Verify the result
@@ -1029,7 +1031,7 @@ class TestPagesMixin:
             page_id=page_id,
             status="historical",
             version=version,
-            expand="body.storage,version,space,children.attachment",
+            expand="body.storage,version,space,children.attachment,history",
         )
 
         # Verify result is a ConfluencePage
@@ -1453,7 +1455,8 @@ class TestPagesOAuthMixin:
 
             # Assert that v2 API was used instead of v1
             mock_v2_adapter.get_page.assert_called_once_with(
-                page_id=page_id, expand="body.storage,version,space,children.attachment"
+                page_id=page_id,
+                expand="body.storage,version,space,children.attachment,history",
             )
 
             # Verify v1 API was NOT called
@@ -1544,7 +1547,7 @@ class TestPagesOAuthMixin:
             mock_v2_adapter.get_page_by_version.assert_called_once_with(
                 page_id=page_id,
                 version=version,
-                expand="body.storage,version,space,children.attachment",
+                expand="body.storage,version,space,children.attachment,history",
             )
 
             # Verify v1 API was NOT called


### PR DESCRIPTION
Integrates [upstream PR #1117](https://github.com/sooperset/mcp-atlassian/pull/1117) into community/main.

Closes #247