### PR TITLE
fix(jira): handle 'me' identifier in get_user_profile (closes #69)

### DIFF
--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -385,6 +385,11 @@ class UsersMixin(JiraClient):
                 fails.
             Exception: For other API errors.
         """
+        # Handle 'me' as a special case — resolve to current user's account ID
+        if identifier.lower() == "me":
+            resolved_id = self.get_current_user_account_id()
+            return self.get_user_profile_by_identifier(resolved_id)
+
         api_kwargs = self._determine_user_api_params(identifier)
 
         try:

--- a/tests/e2e/cloud/test_jira_user_profile_me.py
+++ b/tests/e2e/cloud/test_jira_user_profile_me.py
@@ -1,0 +1,31 @@
+"""E2E: get_user_profile handles 'me' identifier (regression #596)."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_atlassian.jira import JiraFetcher
+
+from .conftest import CloudInstanceInfo
+
+pytestmark = pytest.mark.cloud_e2e
+
+
+class TestJiraUserProfileMe:
+    """get_user_profile_by_identifier should handle 'me' without crashing.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/596
+    Bug: calling get_user_profile with 'me' crashes with unhelpful error.
+    """
+
+    def test_get_user_profile_with_me_identifier(
+        self,
+        jira_fetcher: JiraFetcher,
+        cloud_instance: CloudInstanceInfo,
+    ) -> None:
+        """get_user_profile_by_identifier('me') returns current user."""
+        result = jira_fetcher.get_user_profile_by_identifier("me")
+        assert result is not None, "'me' identifier returned None"
+        assert result.account_id or result.display_name, (
+            "User profile missing account_id and display_name"
+        )

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -903,3 +903,47 @@ class TestUnicodeLookup:
         # Searching with the email should match (case insensitive)
         account_id = users_mixin._lookup_user_directly("TËST@EXAMPLE.COM")
         assert account_id == "email-account-id"
+
+
+class TestUserProfileMeIdentifier:
+    """get_user_profile_by_identifier handles 'me' identifier.
+
+    Regression for https://github.com/sooperset/mcp-atlassian/issues/596
+    Also addresses https://github.com/sooperset/mcp-atlassian/issues/459
+    """
+
+    def test_me_resolves_to_current_user(self, jira_fetcher):
+        """'me' identifier resolves via get_current_user_account_id."""
+        user_response = {
+            "accountId": "5b10ac8d82e05b22cc7d4ef5",
+            "displayName": "Test User",
+            "emailAddress": "test@example.com",
+            "active": True,
+        }
+        with patch.object(
+            jira_fetcher,
+            "get_current_user_account_id",
+            return_value="5b10ac8d82e05b22cc7d4ef5",
+        ) as mock_get_current:
+            jira_fetcher.jira.user = MagicMock(return_value=user_response)
+            result = jira_fetcher.get_user_profile_by_identifier("me")
+            assert result is not None
+            assert result.account_id == "5b10ac8d82e05b22cc7d4ef5"
+            mock_get_current.assert_called_once()
+
+    def test_me_case_insensitive(self, jira_fetcher):
+        """'Me', 'ME', 'mE' all resolve to current user."""
+        user_response = {
+            "accountId": "5b10ac8d82e05b22cc7d4ef5",
+            "displayName": "Test User",
+            "active": True,
+        }
+        with patch.object(
+            jira_fetcher,
+            "get_current_user_account_id",
+            return_value="5b10ac8d82e05b22cc7d4ef5",
+        ):
+            jira_fetcher.jira.user = MagicMock(return_value=user_response)
+            for variant in ["Me", "ME", "mE"]:
+                result = jira_fetcher.get_user_profile_by_identifier(variant)
+                assert result is not None


### PR DESCRIPTION
Integrates [upstream PR #1120](https://github.com/sooperset/mcp-atlassian/pull/1120) into community/main.