### PR TITLE
feat(auth): add SSO cookie support for Jira and Confluence (closes #103)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,3 +239,10 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 
 # Confluence-specific custom headers.
 #CONFLUENCE_CUSTOM_HEADERS=X-Confluence-Service=mcp-integration,X-Custom-Auth=confluence-token,X-ALB-Token=secret-token
+
+# --- Cookie Configuration (Advanced) ---
+# Raw cookie string attached to every Jira/Confluence request.
+# Useful behind SSO / reverse proxies that require session cookies.
+# Format: name=value pairs separated by "; " (exactly as a Cookie header).
+#JIRA_COOKIE=JSESSIONID=abc123; other_cookie=xyz
+#CONFLUENCE_COOKIE=JSESSIONID=abc123; other_cookie=xyz

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -145,6 +145,11 @@ class ConfluenceClient:
         if self.config.custom_headers:
             self._apply_custom_headers()
 
+        # Apply cookie if configured
+        if self.config.cookie:
+            self.confluence._session.headers["Cookie"] = self.config.cookie
+            logger.debug("Applied configured cookie to Confluence session")
+
         # Import here to avoid circular imports
         from ..preprocessing.confluence import ConfluencePreprocessor
 

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -40,6 +40,7 @@ class ConfluenceConfig:
     client_key: str | None = None  # Client private key file path (.pem)
     client_key_password: str | None = None  # Password for encrypted private key
     timeout: int = 75  # Connection timeout in seconds
+    cookie: str | None = None  # Raw cookie string to attach to all requests
 
     @property
     def is_cloud(self) -> bool:
@@ -187,6 +188,9 @@ class ConfluenceConfig:
         ):
             timeout = int(os.getenv("CONFLUENCE_TIMEOUT", "75"))
 
+        # Cookie configuration
+        cookie = os.getenv("CONFLUENCE_COOKIE")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -205,6 +209,7 @@ class ConfluenceConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cookie=cookie,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -158,6 +158,11 @@ class JiraClient:
         if self.config.custom_headers:
             self._apply_custom_headers()
 
+        # Apply cookie if configured
+        if self.config.cookie:
+            self.jira._session.headers["Cookie"] = self.config.cookie
+            logger.debug("Applied configured cookie to Jira session")
+
         # Initialize the text preprocessor for text processing capabilities
         self.preprocessor = JiraPreprocessor(
             base_url=self.config.url,

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -116,6 +116,7 @@ class JiraConfig:
     client_key_password: str | None = None  # Password for encrypted private key
     sla_config: SLAConfig | None = None  # Optional SLA configuration
     timeout: int = 75  # Connection timeout in seconds
+    cookie: str | None = None  # Raw cookie string to attach to all requests
 
     @property
     def is_cloud(self) -> bool:
@@ -262,6 +263,9 @@ class JiraConfig:
         if os.getenv("JIRA_TIMEOUT") and os.getenv("JIRA_TIMEOUT", "").isdigit():
             timeout = int(os.getenv("JIRA_TIMEOUT", "75"))
 
+        # Cookie configuration
+        cookie = os.getenv("JIRA_COOKIE")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -281,6 +285,7 @@ class JiraConfig:
             client_key=client_key,
             client_key_password=client_key_password,
             timeout=timeout,
+            cookie=cookie,
         )
 
     def is_auth_configured(self) -> bool:

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -329,3 +329,32 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://confluence.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+def test_from_env_with_cookie():
+    """Test that from_env reads CONFLUENCE_COOKIE and stores it in config."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+            "CONFLUENCE_COOKIE": "JSESSIONID=abc123; other=xyz",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cookie == "JSESSIONID=abc123; other=xyz"
+
+
+def test_from_env_without_cookie():
+    """Test that cookie defaults to None when CONFLUENCE_COOKIE is not set."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_URL": "https://confluence.example.com",
+            "CONFLUENCE_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cookie is None

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -401,3 +401,32 @@ def test_from_env_oauth_enable_with_server_url():
         assert config.url == "https://jira.example.com"
         assert config.auth_type == "oauth"
         assert config.is_cloud is False
+
+
+def test_from_env_with_cookie():
+    """Test that from_env reads JIRA_COOKIE and stores it in config."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+            "JIRA_COOKIE": "JSESSIONID=abc123; other=xyz",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cookie == "JSESSIONID=abc123; other=xyz"
+
+
+def test_from_env_without_cookie():
+    """Test that cookie defaults to None when JIRA_COOKIE is not set."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://jira.example.com",
+            "JIRA_PERSONAL_TOKEN": "test_pat",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cookie is None


### PR DESCRIPTION
Integrates [upstream PR #1128](https://github.com/sooperset/mcp-atlassian/pull/1128) into community/main.\n\n**Security review required** — third-party contribution.