### PR TITLE
feat(confluence): add confluence_update_page_section tool for lossless partial page updates

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 import requests
+from bs4 import BeautifulSoup, Tag
 from requests.exceptions import HTTPError
 
 from ..models.confluence import ConfluencePage
@@ -716,6 +717,135 @@ class PagesMixin(ConfluenceClient):
         except Exception as e:
             logger.error(f"Error updating page {page_id}: {str(e)}")
             raise Exception(f"Failed to update page {page_id}: {str(e)}") from e
+
+    def update_page_section(
+        self,
+        page_id: str,
+        heading_text: str,
+        new_content: str,
+        *,
+        content_format: str = "markdown",
+        is_minor_edit: bool = False,
+        version_comment: str = "",
+    ) -> ConfluencePage:
+        """Update a single section of a Confluence page without affecting the rest.
+
+        Fetches the page in raw storage format, locates the section identified by
+        its heading text, replaces only the content between that heading and the
+        next heading of the same or higher level, and writes the modified storage
+        XML back. This is lossless: macros, layouts, mentions, and all other
+        Confluence-specific elements outside the target section are preserved.
+
+        Args:
+            page_id: The ID of the page to update.
+            heading_text: Exact text of the heading that starts the section to
+                replace. Matching is case-sensitive and whitespace-normalised.
+            new_content: Replacement content for the section body (excluding the
+                heading itself).
+            content_format: Format of new_content — ``'markdown'`` (default) or
+                ``'storage'``. When ``'markdown'``, the content is
+                converted to Confluence storage format before insertion.
+                (keyword-only)
+            is_minor_edit: Whether to flag the page version as a minor edit.
+                (keyword-only)
+            version_comment: Optional version comment. (keyword-only)
+
+        Returns:
+            Updated ``ConfluencePage`` with the section replaced.
+
+        Raises:
+            ValueError: If ``heading_text`` is not found on the page, or if
+                ``content_format`` is not one of the accepted values.
+            Exception: If retrieving or updating the page fails.
+        """
+        if content_format not in ("markdown", "storage"):
+            raise ValueError(
+                f"Invalid content_format '{content_format}'. "
+                "Must be 'markdown' or 'storage'."
+            )
+
+        # 1. Fetch raw storage XML — no markdown conversion so nothing is lost.
+        page = self.get_page_content(page_id, convert_to_markdown=False)
+        raw_storage = page.content or ""
+
+        # 2. Convert new_content to storage format when necessary.
+        if content_format == "markdown":
+            new_storage_fragment = self.preprocessor.markdown_to_confluence_storage(
+                new_content
+            )
+        else:
+            new_storage_fragment = new_content
+
+        # 3. Parse the full storage XML with BeautifulSoup.
+        soup = BeautifulSoup(raw_storage, "html.parser")
+
+        heading_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
+        target_heading: Tag | None = None
+        for tag in soup.find_all(heading_tags):
+            if (
+                isinstance(tag, Tag)
+                and tag.get_text(strip=True) == heading_text.strip()
+            ):
+                target_heading = tag
+                break
+
+        if target_heading is None:
+            raise ValueError(
+                f"Heading '{heading_text.strip()}' not found in page {page_id}. "
+                "Heading text must match exactly (case-sensitive)."
+            )
+
+        heading_level = int(target_heading.name[1])  # e.g. "h2" → 2
+
+        # 4. Collect all sibling nodes that belong to this section (between
+        #    this heading and the next heading of the same or higher level).
+        #    NavigableString nodes (whitespace, text) are included alongside
+        #    Tag nodes, so we type the list broadly.
+        siblings_to_remove: list = []
+        current = target_heading.next_sibling
+        while current is not None:
+            if isinstance(current, Tag) and current.name in heading_tags:
+                if int(current.name[1]) <= heading_level:
+                    break
+            siblings_to_remove.append(current)
+            current = current.next_sibling
+
+        # 5. Capture heading HTML, remove old section nodes, then splice in the
+        #    new fragment via string operations — avoids moving nodes between
+        #    BS4 trees which causes type and mutation issues.
+        heading_html = str(target_heading)
+        for node in siblings_to_remove:
+            node.extract()
+
+        pruned_html = str(soup)
+        heading_pos = pruned_html.find(heading_html)
+        if heading_pos == -1:
+            # Should not happen: heading was found by BS4 and serialised above.
+            # Guard against unexpected BS4 serialisation edge cases.
+            raise ValueError(
+                f"Internal error: could not locate heading '{heading_text.strip()}' "
+                "in serialised page HTML. Please report this as a bug."
+            )
+        insert_at = heading_pos + len(heading_html)
+        final_html = (
+            pruned_html[:insert_at] + new_storage_fragment + pruned_html[insert_at:]
+        )
+
+        # 7. Write the full modified storage XML back — no format conversion,
+        #    so every macro and element outside the section is untouched.
+        logger.debug(
+            f"Updating section '{heading_text}' on page {page_id} "
+            "using lossless storage-format write-back."
+        )
+        return self.update_page(
+            page_id=page_id,
+            title=page.title or "",
+            body=final_html,
+            is_markdown=False,
+            content_representation="storage",
+            is_minor_edit=is_minor_edit,
+            version_comment=version_comment,
+        )
 
     def get_page_children(
         self,

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -2983,3 +2983,161 @@ class TestPageHierarchy:
 
         assert result["total_pages"] == 1
         assert result["has_more"] is False
+
+
+class TestUpdatePageSection:
+    """Tests for PagesMixin.update_page_section."""
+
+    @pytest.fixture
+    def pages_mixin(self, confluence_client):
+        """Create a PagesMixin instance for testing."""
+        with patch(
+            "mcp_atlassian.confluence.pages.ConfluenceClient.__init__"
+        ) as mock_init:
+            mock_init.return_value = None
+            mixin = PagesMixin()
+            mixin.confluence = confluence_client.confluence
+            mixin.config = confluence_client.config
+            mixin.preprocessor = confluence_client.preprocessor
+            return mixin
+
+    def _make_page(self, page_id: str, title: str, storage_html: str) -> ConfluencePage:
+        return ConfluencePage(
+            id=page_id,
+            title=title,
+            content=storage_html,
+            space={"key": "PROJ", "name": "Project"},
+            version={"number": 1},
+        )
+
+    def test_replaces_section_content(self, pages_mixin):
+        """Section body is replaced; heading and surrounding content are kept."""
+        storage = (
+            "<h1>Intro</h1><p>intro text</p>"
+            "<h2>Target Section</h2><p>old content</p>"
+            "<h2>Another Section</h2><p>other content</p>"
+        )
+        raw_page = self._make_page("123", "My Page", storage)
+        updated_page = self._make_page("123", "My Page", "updated")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new content</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
+        ):
+            result = pages_mixin.update_page_section(
+                page_id="123",
+                heading_text="Target Section",
+                new_content="new content",
+            )
+
+        assert result is updated_page
+        call_body: str = mock_update.call_args.kwargs["body"]
+        # Heading preserved
+        assert "<h2>Target Section</h2>" in call_body
+        # New content inserted
+        assert "<p>new content</p>" in call_body
+        # Old content removed
+        assert "old content" not in call_body
+        # Sibling section untouched
+        assert "<h2>Another Section</h2>" in call_body
+        assert "<p>other content</p>" in call_body
+        # Written back as storage format
+        assert mock_update.call_args.kwargs["is_markdown"] is False
+        assert mock_update.call_args.kwargs["content_representation"] == "storage"
+
+    def test_stops_at_same_level_heading(self, pages_mixin):
+        """Content replacement stops at the next heading of the same level."""
+        storage = (
+            "<h2>Section A</h2><p>a content</p>"
+            "<h2>Section B</h2><p>b content</p><h3>Sub</h3><p>sub</p>"
+            "<h2>Section C</h2><p>c content</p>"
+        )
+        raw_page = self._make_page("1", "P", storage)
+        updated_page = self._make_page("1", "P", "")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new b</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
+        ):
+            pages_mixin.update_page_section("1", "Section B", "new b")
+
+        body: str = mock_update.call_args.kwargs["body"]
+        assert "b content" not in body
+        assert "<p>new b</p>" in body
+        # Section C must be intact
+        assert "<h2>Section C</h2>" in body
+        assert "<p>c content</p>" in body
+        # Section A must be intact
+        assert "<h2>Section A</h2>" in body
+        assert "<p>a content</p>" in body
+
+    def test_heading_not_found_raises(self, pages_mixin):
+        """ValueError is raised when heading text does not exist on the page."""
+        raw_page = self._make_page("1", "P", "<h2>Existing</h2><p>content</p>")
+
+        with patch.object(pages_mixin, "get_page_content", return_value=raw_page):
+            with pytest.raises(ValueError, match="not found in page"):
+                pages_mixin.update_page_section("1", "Nonexistent Heading", "data")
+
+    def test_invalid_content_format_raises(self, pages_mixin):
+        """ValueError is raised for unsupported content_format values."""
+        with pytest.raises(ValueError, match="Invalid content_format"):
+            pages_mixin.update_page_section(
+                "1", "Heading", "content", content_format="wiki"
+            )
+
+    def test_macros_outside_section_preserved(self, pages_mixin):
+        """Confluence macros outside the target section survive the update."""
+        macro = (
+            '<ac:structured-macro ac:name="toc">'
+            '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        storage = f"{macro}<h2>Section</h2><p>old</p><h2>Other</h2><p>other</p>"
+        raw_page = self._make_page("1", "P", storage)
+        updated_page = self._make_page("1", "P", "")
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
+            "<p>new</p>"
+        )
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(
+                pages_mixin, "update_page", return_value=updated_page
+            ) as mock_update,
+        ):
+            pages_mixin.update_page_section("1", "Section", "new")
+
+        body: str = mock_update.call_args.kwargs["body"]
+        assert 'ac:name="toc"' in body
+
+    def test_storage_format_content_not_converted(self, pages_mixin):
+        """When content_format='storage', markdown_to_confluence_storage is not called."""
+        raw_page = self._make_page("1", "P", "<h2>Section</h2><p>old</p>")
+        updated_page = self._make_page("1", "P", "")
+
+        with (
+            patch.object(pages_mixin, "get_page_content", return_value=raw_page),
+            patch.object(pages_mixin, "update_page", return_value=updated_page),
+        ):
+            pages_mixin.update_page_section(
+                "1",
+                "Section",
+                "<p>raw storage</p>",
+                content_format="storage",
+            )
+
+        pages_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 25, (
-            f"Expected 25 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 26, (
+            f"Expected 26 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
Integrates [upstream PR #1141](https://github.com/sooperset/mcp-atlassian/pull/1141) into community/main.\n\n**Security review required** — third-party contribution.