### PR TITLE
fix(jira): use correct case-sensitive applicationType values for dev-status API

### DIFF
--- a/src/mcp_atlassian/jira/development.py
+++ b/src/mcp_atlassian/jira/development.py
@@ -26,7 +26,9 @@ class DevelopmentMixin(JiraClient):
         Args:
             issue_key: The issue key (e.g., PROJECT-123)
             application_type: Filter by application type
-                (e.g., 'stash', 'github', 'bitbucket').
+                (e.g., 'stash', 'GitHub', 'bitbucket').
+                Values are case-sensitive (the dev-status API
+                returns empty results or 500 errors on mismatch).
                 If None, tries common application types.
             data_type: Filter by data type
                 (e.g., 'pullrequest', 'branch', 'repository').
@@ -65,8 +67,9 @@ class DevelopmentMixin(JiraClient):
                 )
 
             # Otherwise, try common application types and merge results
-            # Common types: stash (Bitbucket Server), bitbucket, github, gitlab
-            app_types = ["stash", "bitbucket", "github", "gitlab"]
+            # Values are case-sensitive — the dev-status API requires the
+            # exact casing registered by each DVCS connector plugin.
+            app_types = ["stash", "bitbucket", "GitHub", "GitLab"]
             # Data types to try for each app type
             data_types = ["pullrequest", "branch", "repository"]
             merged_result: dict[str, Any] = {
@@ -132,7 +135,7 @@ class DevelopmentMixin(JiraClient):
         Args:
             issue_key: The issue key
             issue_id: The numeric issue ID
-            application_type: The application type (stash, github, etc.)
+            application_type: The application type (stash, GitHub, etc.) — case-sensitive
             data_type: Optional data type filter
 
         Returns:

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -3347,8 +3347,8 @@ async def get_issue_development_info(
         str | None,
         Field(
             description=(
-                "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "(Optional) Filter by application type (case-sensitive). "
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'GitLab'"
             )
         ),
     ] = None,
@@ -3412,8 +3412,8 @@ async def get_issues_development_info(
         str | None,
         Field(
             description=(
-                "(Optional) Filter by application type. "
-                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'github', 'gitlab'"
+                "(Optional) Filter by application type (case-sensitive). "
+                "Examples: 'stash' (Bitbucket Server), 'bitbucket', 'GitHub', 'GitLab'"
             )
         ),
     ] = None,


### PR DESCRIPTION
Integrates [upstream PR #1153](https://github.com/sooperset/mcp-atlassian/pull/1153) into community/main.

**Author:** sfc-gh-hdibani (untrusted — security review required)

Fixes case-sensitivity bug where `github`/`gitlab` should be `GitHub`/`GitLab` in the dev-status API.