### PR TITLE
feat(jira): add use_display_names for human-readable custom field keys (closes #84)

### DIFF
--- a/docs/tools/jira-issues.mdx
+++ b/docs/tools/jira-issues.mdx
@@ -17,6 +17,7 @@ Get details of a specific Jira issue including its Epic links and relationship i
 | `comment_limit` | `integer` | No | Maximum number of comments to include (0 or null for no comments) |
 | `properties` | `string` | No | (Optional) A comma-separated list of issue properties to return |
 | `update_history` | `boolean` | No | Whether to update the issue view history for the requesting user |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -25,6 +26,10 @@ Get details of a specific Jira issue including its Epic links and relationship i
 
 <Tip>
 Use `fields: "*all"` to get all fields including custom ones. Use `expand: "renderedFields"` for rendered HTML content.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
 </Tip>
 
 

--- a/docs/tools/jira-search-fields.mdx
+++ b/docs/tools/jira-search-fields.mdx
@@ -18,6 +18,7 @@ Search Jira issues using JQL (Jira Query Language).
 | `projects_filter` | `string` | No | (Optional) Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided. |
 | `expand` | `string` | No | (Optional) fields to expand. Examples: 'renderedFields', 'transitions', 'changelog' |
 | `page_token` | `string` | No | Pagination token from a previous search result. Cloud only — Server/DC uses `start_at` for pagination. |
+| `use_display_names` | `boolean` | No | When true, custom field keys in the output use human-readable display names (e.g. 'Story Points') instead of opaque IDs (e.g. 'customfield_10243'). The `names` expansion is added automatically. Standard fields are unaffected. Default: false. |
 **Example:**
 
 ```json
@@ -26,6 +27,10 @@ Search Jira issues using JQL (Jira Query Language).
 
 <Tip>
 Always use `ORDER BY` for deterministic results. Use `fields` parameter to limit returned data for faster queries.
+</Tip>
+
+<Tip>
+Set `use_display_names: true` to get human-readable keys for custom fields instead of opaque IDs like `customfield_XXXXX`.
 </Tip>
 
 

--- a/src/mcp_atlassian/models/jira/issue.py
+++ b/src/mcp_atlassian/models/jira/issue.py
@@ -761,6 +761,95 @@ class JiraIssue(ApiModel, TimestampMixin):
 
         return None, None
 
+    def get_custom_field_by_name(
+        self, display_name: str, *, case_sensitive: bool = False
+    ) -> Any:
+        """Look up a custom field value by its human-readable display name.
+
+        This is a convenience wrapper over the internal ``custom_fields`` dict
+        (which is keyed by ``customfield_XXXXX``).  It searches the ``name``
+        entry stored inside each value object, so the underlying data structure
+        is completely untouched.
+
+        Args:
+            display_name: The human-readable name of the field
+                (e.g. ``"Story Points"``, ``"Severity"``).
+            case_sensitive: If *False* (default) the comparison is
+                case-insensitive.
+
+        Returns:
+            The processed field value if found, or *None*.
+        """
+        target = display_name if case_sensitive else display_name.lower()
+        for field_data in self.custom_fields.values():
+            if not isinstance(field_data, dict):
+                continue
+            stored_name = field_data.get("name")
+            if stored_name is None:
+                continue
+            candidate = stored_name if case_sensitive else stored_name.lower()
+            if candidate == target:
+                return self._process_custom_field_value(field_data.get("value"))
+        return None
+
+    @property
+    def custom_fields_by_display_name(self) -> dict[str, Any]:
+        """Return ``custom_fields`` re-keyed by display name.
+
+        Fields that do not carry a ``name`` entry keep their original
+        ``customfield_XXXXX`` key so nothing is silently dropped.
+
+        Each value retains the upstream structure
+        (``{"value": …, "name": …}``) with an additional ``"field_id"`` key
+        for reverse-lookup convenience.
+
+        Returns:
+            A **new** dict — the original ``custom_fields`` is never mutated.
+        """
+        result: dict[str, Any] = {}
+        for field_id, field_data in self.custom_fields.items():
+            if not isinstance(field_data, dict):
+                result[field_id] = field_data
+                continue
+            display_key = field_data.get("name", field_id)
+            entry = {**field_data, "field_id": field_id}
+            result[display_key] = entry
+        return result
+
+    def to_display_name_dict(self) -> dict[str, Any]:
+        """Like ``to_simplified_dict`` but with custom fields keyed by display name.
+
+        Standard fields (summary, status, etc.) are identical to
+        ``to_simplified_dict()``.  Only the custom-field section changes:
+        each ``customfield_XXXXX`` key is replaced by its human-readable
+        name when one is available.
+
+        Returns:
+            A simplified dict suitable for tool / API output where custom
+            fields use human-friendly keys.
+        """
+        base = self.to_simplified_dict()
+
+        rekeyed_customs: dict[str, Any] = {}
+        removed_keys: list[str] = []
+
+        for key, value in base.items():
+            if not key.startswith("customfield_"):
+                continue
+            removed_keys.append(key)
+            if isinstance(value, dict) and "name" in value:
+                display_key = value["name"]
+                entry = {**value, "field_id": key}
+                rekeyed_customs[display_key] = entry
+            else:
+                rekeyed_customs[key] = value
+
+        for k in removed_keys:
+            del base[k]
+
+        base.update(rekeyed_customs)
+        return base
+
     def _get_epic_name(self) -> str | None:
         """Get the epic name from custom fields if available."""
         # Try each pattern in order

--- a/src/mcp_atlassian/models/jira/search.py
+++ b/src/mcp_atlassian/models/jira/search.py
@@ -49,9 +49,15 @@ class JiraSearchResult(ApiModel):
 
         issues = []
         issues_data = data.get("issues", [])
+        # The 'names' map (field ID → display name) lives at the top level
+        # of search responses.  Propagate it into each issue dict so that
+        # JiraIssue.from_api_response can populate display names.
+        top_level_names = data.get("names")
         if isinstance(issues_data, list):
             for issue_data in issues_data:
                 if issue_data:
+                    if top_level_names and isinstance(issue_data, dict):
+                        issue_data = {**issue_data, "names": top_level_names}
                     requested_fields = kwargs.get("requested_fields")
                     issues.append(
                         JiraIssue.from_api_response(
@@ -108,6 +114,18 @@ class JiraSearchResult(ApiModel):
             "start_at": self.start_at,
             "max_results": self.max_results,
             "issues": [issue.to_simplified_dict() for issue in self.issues],
+        }
+        if self.next_page_token is not None:
+            result["next_page_token"] = self.next_page_token
+        return result
+
+    def to_display_name_dict(self) -> dict[str, Any]:
+        """Like ``to_simplified_dict`` but with display-name keys on each issue."""
+        result: dict[str, Any] = {
+            "total": self.total,
+            "start_at": self.start_at,
+            "max_results": self.max_results,
+            "issues": [issue.to_display_name_dict() for issue in self.issues],
         }
         if self.next_page_token is not None:
             result["next_page_token"] = self.next_page_token

--- a/src/mcp_atlassian/servers/jira.py
+++ b/src/mcp_atlassian/servers/jira.py
@@ -362,6 +362,18 @@ async def get_issue(
             default=None,
         ),
     ] = None,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Get details of a specific Jira issue.
 
@@ -379,6 +391,7 @@ async def get_issue(
         properties: Issue properties to return.
         update_history: Whether to update issue view history.
         include: Comma-separated enrichment sections to inline.
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the Jira issue object.
@@ -408,6 +421,10 @@ async def get_issue(
         else:
             expand = ",".join(expand_additions)
 
+    # Automatically include 'names' expansion when display names are requested
+    if use_display_names and (not expand or "names" not in expand):
+        expand = f"{expand},names" if expand else "names"
+
     # Fetch the issue (with augmented expand)
     issue = jira.get_issue(
         issue_key=issue_key,
@@ -417,7 +434,10 @@ async def get_issue(
         properties=properties.split(",") if properties else None,
         update_history=update_history,
     )
-    result = issue.to_simplified_dict()
+    if use_display_names:
+        result = issue.to_display_name_dict()
+    else:
+        result = issue.to_simplified_dict()
 
     # Enrichments that require separate API calls
     if "remote_links" in include_sections:
@@ -431,7 +451,6 @@ async def get_issue(
             result["watchers"] = jira.get_issue_watchers(issue_key)
         except Exception:  # noqa: BLE001
             result["watchers"] = {}
-
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 
@@ -503,6 +522,18 @@ async def search(
             default=None,
         ),
     ] = None,
+    use_display_names: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, custom field keys in the output use human-readable "
+                "display names (e.g. 'Story Points') instead of opaque IDs "
+                "(e.g. 'customfield_10243'). The 'names' expansion is added "
+                "automatically. Standard fields are unaffected."
+            ),
+            default=False,
+        ),
+    ] = False,
 ) -> str:
     """Search Jira issues using JQL (Jira Query Language).
 
@@ -515,6 +546,7 @@ async def search(
         projects_filter: Comma-separated list of project keys to filter by.
         expand: Optional fields to expand.
         page_token: Pagination token from a previous search result (Cloud only).
+        use_display_names: Opt into human-readable custom field keys.
 
     Returns:
         JSON string representing the search results including pagination info.
@@ -523,6 +555,10 @@ async def search(
     fields_list: str | list[str] | None = fields
     if fields and fields != "*all":
         fields_list = [f.strip() for f in fields.split(",")]
+
+    # Automatically include 'names' expansion when display names are requested
+    if use_display_names and (not expand or "names" not in expand):
+        expand = f"{expand},names" if expand else "names"
 
     search_result = jira.search_issues(
         jql=jql,
@@ -533,7 +569,10 @@ async def search(
         projects_filter=projects_filter,
         page_token=page_token,
     )
-    result = search_result.to_simplified_dict()
+    if use_display_names:
+        result = search_result.to_display_name_dict()
+    else:
+        result = search_result.to_simplified_dict()
     return json.dumps(result, indent=2, ensure_ascii=False)
 
 

--- a/tests/unit/models/test_jira_issue_model.py
+++ b/tests/unit/models/test_jira_issue_model.py
@@ -773,3 +773,113 @@ class TestProcessCustomFieldValue:
         field = simplified["customfield_10200"]
         assert field["name"] == "Okapya Checklist"
         assert field["value"] == checklist_items
+
+
+class TestDisplayNameMethods:
+    """Tests for the additive display-name helper methods.
+
+    These methods sit on top of the existing JiraIssue model without
+    modifying any existing behavior.
+    """
+
+    @pytest.fixture()
+    def issue_with_names(self):
+        """Create a JiraIssue whose custom fields carry display names."""
+        api_data = {
+            "id": "100",
+            "key": "DN-1",
+            "fields": {
+                "summary": "Display name test",
+                "customfield_10001": "text value",
+                "customfield_10002": {"value": "Option A"},
+                "customfield_10003": [
+                    {"value": "Multi 1"},
+                    {"value": "Multi 2"},
+                ],
+                "customfield_10099": "orphan without a name",
+            },
+            "names": {
+                "customfield_10001": "Story Points",
+                "customfield_10002": "Severity",
+                "customfield_10003": "Affected Versions",
+            },
+        }
+        return JiraIssue.from_api_response(api_data, requested_fields="*all")
+
+    # -- get_custom_field_by_name -----------------------------------------
+
+    def test_get_custom_field_by_name_exact(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Story Points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_insensitive(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("story points")
+        assert result == "text value"
+
+    def test_get_custom_field_by_name_case_sensitive_miss(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name(
+            "story points", case_sensitive=True
+        )
+        assert result is None
+
+    def test_get_custom_field_by_name_select(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Severity")
+        assert result == "Option A"
+
+    def test_get_custom_field_by_name_multiselect(self, issue_with_names):
+        result = issue_with_names.get_custom_field_by_name("Affected Versions")
+        assert result == ["Multi 1", "Multi 2"]
+
+    def test_get_custom_field_by_name_not_found(self, issue_with_names):
+        assert issue_with_names.get_custom_field_by_name("Nonexistent") is None
+
+    # -- custom_fields_by_display_name property ---------------------------
+
+    def test_property_rekeys_by_display_name(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "Story Points" in by_name
+        assert "Severity" in by_name
+        assert "Affected Versions" in by_name
+
+    def test_property_includes_field_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert by_name["Story Points"]["field_id"] == "customfield_10001"
+        assert by_name["Severity"]["field_id"] == "customfield_10002"
+
+    def test_property_keeps_orphans_by_raw_id(self, issue_with_names):
+        by_name = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10099" in by_name
+        assert by_name["customfield_10099"]["field_id"] == "customfield_10099"
+
+    def test_property_does_not_mutate_original(self, issue_with_names):
+        _ = issue_with_names.custom_fields_by_display_name
+        assert "customfield_10001" in issue_with_names.custom_fields
+
+    # -- to_display_name_dict ---------------------------------------------
+
+    def test_display_name_dict_rekeys_customs(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "Story Points" in d
+        assert "Severity" in d
+        assert "Affected Versions" in d
+        assert "customfield_10001" not in d
+        assert "customfield_10002" not in d
+
+    def test_display_name_dict_preserves_standard_fields(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["key"] == "DN-1"
+        assert d["summary"] == "Display name test"
+
+    def test_display_name_dict_includes_field_id(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert d["Story Points"]["field_id"] == "customfield_10001"
+
+    def test_display_name_dict_orphan_kept(self, issue_with_names):
+        d = issue_with_names.to_display_name_dict()
+        assert "customfield_10099" in d
+
+    def test_original_simplified_dict_unchanged(self, issue_with_names):
+        """to_simplified_dict must still use customfield_XXXXX keys."""
+        s = issue_with_names.to_simplified_dict()
+        assert "customfield_10001" in s
+        assert "Story Points" not in s

--- a/tests/unit/servers/test_jira_server.py
+++ b/tests/unit/servers/test_jira_server.py
@@ -2626,3 +2626,100 @@ async def test_assign_issue_error(jira_client, mock_jira_fetcher):
             },
         )
     assert "User not found" in str(excinfo.value)
+
+
+# ============================================================================
+# Display-Name Feature Tests
+# ============================================================================
+
+
+@pytest.mark.anyio
+async def test_get_issue_use_display_names(jira_client, mock_jira_fetcher):
+    """Test get_issue with use_display_names=True returns display-name keys."""
+    display_name_response = {
+        "key": "TEST-123",
+        "summary": "Test Issue Summary",
+        "status": {"name": "Open"},
+        "Story Points": {"value": 5, "field_id": "customfield_10243"},
+    }
+
+    def mock_get_issue_dn(
+        issue_key,
+        fields=None,
+        expand=None,
+        comment_limit=10,
+        properties=None,
+        update_history=True,
+    ):
+        mock_issue = MagicMock()
+        mock_issue.to_simplified_dict.return_value = {
+            "key": issue_key,
+            "summary": "Test Issue Summary",
+            "status": {"name": "Open"},
+            "customfield_10243": 5,
+        }
+        mock_issue.to_display_name_dict.return_value = {
+            **display_name_response,
+            "key": issue_key,
+        }
+        return mock_issue
+
+    mock_jira_fetcher.get_issue.side_effect = mock_get_issue_dn
+
+    response = await jira_client.call_tool(
+        "jira_get_issue",
+        {"issue_key": "TEST-123", "use_display_names": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert "Story Points" in content
+    assert "customfield_10243" not in content
+
+    mock_jira_fetcher.get_issue.assert_called_once()
+    call_kwargs = mock_jira_fetcher.get_issue.call_args
+    assert call_kwargs[1]["issue_key"] == "TEST-123"
+    assert call_kwargs[1]["expand"] == "names"
+
+
+@pytest.mark.anyio
+async def test_search_use_display_names(jira_client, mock_jira_fetcher):
+    """Test search with use_display_names=True returns display-name keys."""
+    display_name_issues = [
+        {
+            "key": "PROJ-123",
+            "summary": "First issue",
+            "Story Points": {"value": 3, "field_id": "customfield_10243"},
+        },
+    ]
+
+    def mock_search_dn(jql, **kwargs):
+        mock_search_result = MagicMock()
+        mock_search_result.to_simplified_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": [
+                {"key": "PROJ-123", "summary": "First issue", "customfield_10243": 3},
+            ],
+        }
+        mock_search_result.to_display_name_dict.return_value = {
+            "total": 1,
+            "start_at": kwargs.get("start", 0),
+            "max_results": kwargs.get("limit", 50),
+            "issues": display_name_issues,
+        }
+        return mock_search_result
+
+    mock_jira_fetcher.search_issues.side_effect = mock_search_dn
+
+    response = await jira_client.call_tool(
+        "jira_search",
+        {"jql": "project = TEST", "use_display_names": True},
+    )
+    content = json.loads(response.content[0].text)
+    assert content["issues"][0].get("Story Points") is not None
+    assert "customfield_10243" not in content["issues"][0]
+
+    mock_jira_fetcher.search_issues.assert_called_once()
+    call_kwargs = mock_jira_fetcher.search_issues.call_args
+    assert call_kwargs[1]["jql"] == "project = TEST"
+    assert call_kwargs[1]["expand"] == "names"


### PR DESCRIPTION
Integrates [upstream PR #1156](https://github.com/sooperset/mcp-atlassian/pull/1156) into community/main.

**Upstream issue:** [sooperset/mcp-atlassian#1154](https://github.com/sooperset/mcp-atlassian/issues/1154)
**Author:** faizbawa (untrusted — security review required)

Adds `use_display_names` parameter to `jira_get_issue` and `jira_search` for human-readable custom field keys.

Closes #260