### PR TITLE
fix(auth): require service URL for ATLASSIAN_OAUTH_ENABLE

### DIFF
--- a/src/mcp_atlassian/utils/environment.py
+++ b/src/mcp_atlassian/utils/environment.py
@@ -109,16 +109,15 @@ def get_available_services(
             pat_env="CONFLUENCE_PERSONAL_TOKEN",
         )
 
-    if not confluence_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
-        confluence_is_setup = True
-        logger.info(
-            "Using Confluence minimal OAuth configuration "
-            "- expecting user-provided tokens via headers"
-        )
+        # OAuth enable check with known URL — expecting user-provided tokens via headers
+        if not confluence_is_setup and os.getenv(
+            "ATLASSIAN_OAUTH_ENABLE", ""
+        ).lower() in ("true", "1", "yes"):
+            confluence_is_setup = True
+            logger.info(
+                "Using Confluence OAuth with CONFLUENCE_URL "
+                "- expecting user-provided tokens via headers"
+            )
 
     if not confluence_is_setup:
         confluence_token = headers.get("X-Atlassian-Confluence-Personal-Token")
@@ -148,16 +147,17 @@ def get_available_services(
             pat_env="JIRA_PERSONAL_TOKEN",
         )
 
-    if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
-        jira_is_setup = True
-        logger.info(
-            "Using Jira minimal OAuth configuration "
-            "- expecting user-provided tokens via headers"
-        )
+        # OAuth enable check with known URL — expecting user-provided tokens via headers
+        if not jira_is_setup and os.getenv("ATLASSIAN_OAUTH_ENABLE", "").lower() in (
+            "true",
+            "1",
+            "yes",
+        ):
+            jira_is_setup = True
+            logger.info(
+                "Using Jira OAuth with JIRA_URL "
+                "- expecting user-provided tokens via headers"
+            )
 
     if not jira_is_setup:
         jira_token = headers.get("X-Atlassian-Jira-Personal-Token")

--- a/tests/unit/utils/test_environment.py
+++ b/tests/unit/utils/test_environment.py
@@ -436,7 +436,10 @@ class TestGetAvailableServicesWithHeaders:
             assert "Data Center" in caplog.text
 
     def test_oauth_enable_without_urls(self, caplog):
-        """Test BYOT OAuth mode — ATLASSIAN_OAUTH_ENABLE=true without service URLs."""
+        """Test that ATLASSIAN_OAUTH_ENABLE=true without service URLs does NOT mark services as available.
+
+        The OAuth enable check is now scoped inside the URL check, so a URL is required.
+        """
         with MockEnvironment.clean_env():
             import os
 
@@ -444,17 +447,10 @@ class TestGetAvailableServicesWithHeaders:
 
             result = get_available_services()
             _assert_service_availability(
-                result, confluence_expected=True, jira_expected=True
+                result, confluence_expected=False, jira_expected=False
             )
-            assert_log_contains(
-                caplog,
-                "INFO",
-                "Using Confluence minimal OAuth configuration",
-            )
-            assert_log_contains(
-                caplog,
-                "INFO",
-                "Using Jira minimal OAuth configuration",
+            _assert_authentication_logs(
+                caplog, "not_configured", ["confluence", "jira"]
             )
 
     def test_oauth_enable_with_cloud_url_no_creds(self, caplog):
@@ -476,7 +472,25 @@ class TestGetAvailableServicesWithHeaders:
         ["true", "True", "TRUE", "1", "yes", "YES"],
     )
     def test_oauth_enable_value_variations(self, enable_value, caplog):
-        """Test various ATLASSIAN_OAUTH_ENABLE value formats."""
+        """Test various ATLASSIAN_OAUTH_ENABLE value formats with URLs present."""
+        with MockEnvironment.clean_env():
+            import os
+
+            os.environ["ATLASSIAN_OAUTH_ENABLE"] = enable_value
+            os.environ["CONFLUENCE_URL"] = "https://test.atlassian.net/wiki"
+            os.environ["JIRA_URL"] = "https://test.atlassian.net"
+
+            result = get_available_services()
+            _assert_service_availability(
+                result, confluence_expected=True, jira_expected=True
+            )
+
+    @pytest.mark.parametrize(
+        "enable_value",
+        ["true", "True", "TRUE", "1", "yes", "YES"],
+    )
+    def test_oauth_enable_without_urls_value_variations(self, enable_value, caplog):
+        """Test that ATLASSIAN_OAUTH_ENABLE without URLs returns False regardless of value format."""
         with MockEnvironment.clean_env():
             import os
 
@@ -484,7 +498,7 @@ class TestGetAvailableServicesWithHeaders:
 
             result = get_available_services()
             _assert_service_availability(
-                result, confluence_expected=True, jira_expected=True
+                result, confluence_expected=False, jira_expected=False
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Integrates [upstream PR #1158](https://github.com/sooperset/mcp-atlassian/pull/1158) into community/main.

**Author:** harsh1netapp (untrusted — security review required)

Fixes bug where ATLASSIAN_OAUTH_ENABLE=true without a service URL incorrectly marks services as available.