### PR TITLE
fix: redact auth token in unsupported Authorization type log (closes #75)

### DIFF
--- a/src/mcp_atlassian/servers/main.py
+++ b/src/mcp_atlassian/servers/main.py
@@ -760,11 +760,12 @@ class UserTokenMiddleware:
         elif auth_header.strip():
             # Non-empty but unsupported auth type
             auth_value = auth_header.strip()
-            auth_type = (
-                auth_value.split(" ", 1)[0]
-                if " " in auth_value
-                else f"(masked) {mask_sensitive(auth_value)}"
-            )
+            if " " in auth_value:
+                auth_type = auth_value.split(" ", 1)[0]
+            else:
+                # No space means no type prefix — likely a raw token.
+                # Redact to avoid leaking credentials in logs (OWASP/CWE-532).
+                auth_type = "<redacted>"
             logger.warning(f"Unsupported Authorization type: {auth_type}")
             scope["state"]["auth_validation_error"] = (
                 "Unauthorized: Only 'Bearer <OAuthToken>', "


### PR DESCRIPTION
Integrates [upstream PR #1160](https://github.com/sooperset/mcp-atlassian/pull/1160) into community/main.

**Upstream issue:** [sooperset/mcp-atlassian#1134](https://github.com/sooperset/mcp-atlassian/issues/1134)
**Author:** fahe1em1 (untrusted — security review required)

Supersedes our earlier integration of #1138 (mask_sensitive) with full `<redacted>` per OWASP/CWE-532 standards. Partial masking leaks entropy; full redaction is the industry standard.