### PR TITLE
fix(jira): accept all valid Atlassian account ID formats in assignee resolution

### DIFF
--- a/src/mcp_atlassian/jira/users.py
+++ b/src/mcp_atlassian/jira/users.py
@@ -120,8 +120,14 @@ class UsersMixin(JiraClient):
         Raises:
             ValueError: If the account ID could not be found.
         """
-        # If it looks like an account ID already, return it
-        if assignee.startswith("5") and len(assignee) >= 10:
+        # If it looks like an account ID already, return it.
+        # Atlassian account IDs come in two formats:
+        #   - 24-char hex string: e.g. 606b8fb83a516300764cb19d
+        #   - digits:uuid: e.g. 712020:96a182bb-ee48-4240-8465-a7236ccfce2a
+        if re.fullmatch(r"[0-9a-f]{24}", assignee) or re.fullmatch(
+            r"\d+:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+            assignee,
+        ):
             return assignee
 
         account_id = self._lookup_user_directly(assignee)

--- a/tests/unit/jira/test_users.py
+++ b/tests/unit/jira/test_users.py
@@ -146,15 +146,43 @@ class TestUsersMixin:
         # Verify self.jira.myself was called
         users_mixin.jira.myself.assert_called_once()
 
-    def test_get_account_id_already_account_id(self, users_mixin):
-        """Test that _get_account_id returns the input if it looks like an account ID."""
-        # Call the method with a string that looks like an account ID
-        account_id = users_mixin._get_account_id("5abcdef1234567890")
+    @pytest.mark.parametrize(
+        "account_id",
+        [
+            "5abcdef123456789abcdef12",  # 24-char hex starting with 5
+            "606b8fb83a516300764cb19d",  # 24-char hex starting with 6
+            "712020:96a182bb-ee48-4240-8465-a7236ccfce2a",  # digits:uuid format
+            "557058:32b276cf-1a9f-45e0-8a70-84e38d677be0",  # digits:uuid starting with 5
+            "aabbccdd11223344aabbccdd",  # 24-char hex starting with a
+        ],
+    )
+    def test_get_account_id_already_account_id(self, users_mixin, account_id):
+        """_get_account_id returns the input unchanged for valid account ID formats."""
+        result = users_mixin._get_account_id(account_id)
 
-        # Verify result
-        assert account_id == "5abcdef1234567890"
-        # Verify no lookups were performed
+        assert result == account_id
+        # No lookups should be performed for recognized account IDs
         users_mixin.jira.user_find_by_user_string.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "not_account_id",
+        [
+            "john@example.com",  # email
+            "John Smith",  # display name
+            "jsmith",  # username
+            "abc",  # too short to be an account ID
+        ],
+    )
+    def test_get_account_id_not_account_id_triggers_lookup(
+        self, users_mixin, not_account_id
+    ):
+        """_get_account_id performs lookup for strings that aren't account IDs."""
+        users_mixin._lookup_user_directly = MagicMock(return_value="resolved-id")
+
+        result = users_mixin._get_account_id(not_account_id)
+
+        assert result == "resolved-id"
+        users_mixin._lookup_user_directly.assert_called_once_with(not_account_id)
 
     def test_get_account_id_direct_lookup(self, users_mixin):
         """Test that _get_account_id uses direct lookup."""

--- a/tests/unit/servers/test_transport_lifecycle.py
+++ b/tests/unit/servers/test_transport_lifecycle.py
@@ -78,6 +78,10 @@ class TestTransportLifecycleBehavior:
                             called_coro, "cr_code"
                         ), f"{transport} should use direct run_async execution"
 
+                        # Close unawaited coroutine to avoid RuntimeWarning
+                        if hasattr(called_coro, "close"):
+                            called_coro.close()
+
     @pytest.mark.anyio
     async def test_stdio_no_race_condition(self):
         """Test that stdio transport doesn't create race condition with MCP server.
@@ -177,6 +181,10 @@ class TestTransportLifecycleBehavior:
                             called_coro
                         )
 
+                        # Close unawaited coroutine to avoid RuntimeWarning
+                        if hasattr(called_coro, "close"):
+                            called_coro.close()
+
     @pytest.mark.anyio
     async def test_shutdown_event_handling(self):
         """Test that shutdown events are handled correctly for all transports."""
@@ -236,6 +244,10 @@ class TestTransportLifecycleBehavior:
                         called_coro
                     )
 
+                    # Close unawaited coroutine to avoid RuntimeWarning
+                    if hasattr(called_coro, "close"):
+                        called_coro.close()
+
 
 class TestRegressionPrevention:
     """Tests to prevent regression of specific issues."""
@@ -256,7 +268,7 @@ class TestRegressionPrevention:
     def test_signal_handlers_are_setup(self):
         """Verify signal handlers are properly configured."""
         with patch("mcp_atlassian.setup_signal_handlers") as mock_setup:
-            with patch("asyncio.run"):
+            with patch("asyncio.run") as mock_run:
                 with patch("mcp_atlassian.servers.main.AtlassianMCP"):
                     with patch("sys.argv", ["mcp-atlassian"]):
                         try:
@@ -266,3 +278,9 @@ class TestRegressionPrevention:
 
                     # Signal handlers should always be set up
                     mock_setup.assert_called_once()
+
+                # Close captured coroutines
+                for call in mock_run.call_args_list:
+                    coro = call[0][0] if call[0] else None
+                    if coro and hasattr(coro, "close"):
+                        coro.close()

--- a/tests/unit/test_main_transport_selection.py
+++ b/tests/unit/test_main_transport_selection.py
@@ -22,9 +22,19 @@ class TestMainTransportSelection:
     def mock_asyncio_run(self):
         """Mock asyncio.run to capture what coroutine is executed."""
         with patch("asyncio.run") as mock_run:
-            # Store the coroutine for inspection
-            mock_run.side_effect = lambda coro: setattr(mock_run, "_called_with", coro)
+            captured_coros = []
+
+            def _capture(coro):
+                captured_coros.append(coro)
+                mock_run._called_with = coro
+
+            mock_run.side_effect = _capture
             yield mock_run
+
+            # Close all captured coroutines to avoid RuntimeWarning
+            for coro in captured_coros:
+                if hasattr(coro, "close"):
+                    coro.close()
 
     @pytest.mark.parametrize("transport", ["sse", "streamable-http"])
     def test_http_transports_use_direct_execution(
@@ -148,7 +158,7 @@ class TestMainTransportSelection:
     def test_signal_handlers_always_setup(self, mock_server):
         """Test that signal handlers are set up regardless of transport."""
         with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
-            with patch("asyncio.run"):
+            with patch("asyncio.run") as mock_run:
                 # Patch where it's imported in the main module
                 with patch("mcp_atlassian.setup_signal_handlers") as mock_setup:
                     with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
@@ -161,6 +171,12 @@ class TestMainTransportSelection:
                             # Signal handlers should always be set up
                             mock_setup.assert_called_once()
 
+                # Close captured coroutines
+                for call in mock_run.call_args_list:
+                    coro = call[0][0] if call[0] else None
+                    if coro and hasattr(coro, "close"):
+                        coro.close()
+
     def test_error_handling_preserved(self, mock_server):
         """Test that error handling works correctly for all transports."""
         # Make the server's run_async raise an exception when awaited
@@ -171,10 +187,16 @@ class TestMainTransportSelection:
 
         mock_server.run_async = failing_run_async
 
+        leaked_coros = []
+
+        def _raise_and_capture(coro):
+            leaked_coros.append(coro)
+            raise error
+
         with patch("mcp_atlassian.servers.main.AtlassianMCP", return_value=mock_server):
             with patch("asyncio.run") as mock_run:
                 # Simulate the exception propagating through asyncio.run
-                mock_run.side_effect = error
+                mock_run.side_effect = _raise_and_capture
 
                 with patch.dict("os.environ", {"TRANSPORT": "stdio"}):
                     with patch("sys.argv", ["mcp-atlassian"]):
@@ -188,3 +210,8 @@ class TestMainTransportSelection:
                             assert (
                                 mock_exit.call_args_list[1][0][0] == 0
                             )  # Finally exit
+
+        # Close leaked coroutines to avoid RuntimeWarning
+        for coro in leaked_coros:
+            if hasattr(coro, "close"):
+                coro.close()


### PR DESCRIPTION
Fixes the `startswith("5")` heuristic in `_get_account_id()` that silently rejected valid Atlassian account IDs not starting with "5".

Inspired by [upstream PR #1164](https://github.com/sooperset/mcp-atlassian/pull/1164) (NickLoeza) which identified the bug but had failing CI. This is our own implementation with proper regex and tests.

**Changes:**
- Replace `startswith("5") and len >= 10` with regex matching both formats:
  - 24-char hex: `[0-9a-f]{24}`
  - digits:uuid: `\d+:[0-9a-f]{8}-[0-9a-f]{4}-...-[0-9a-f]{12}`
- 5 parametrized positive tests (hex starting with 5/6/a, digits:uuid starting with 5/7)
- 4 parametrized negative tests (email, display name, username, short string)
- Fix unawaited coroutine RuntimeWarnings in transport lifecycle and transport selection tests

**All tests pass with `-W error` (zero warnings).**