### PR TITLE
fix(docker): upgrade Alpine packages to resolve zlib CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN find /app/.venv -name '__pycache__' -type d -exec rm -rf {} + && \
 # Final stage
 FROM python:3.13-alpine
 
+# Upgrade base packages to pick up security fixes (zlib >= 1.3.2-r0)
+RUN apk update && apk upgrade --no-cache && rm -rf /var/cache/apk/*
+
 # Create a non-root user 'app'
 RUN adduser -D -h /home/app -s /bin/sh app
 WORKDIR /app


### PR DESCRIPTION
Integrates [upstream PR #1169](https://github.com/sooperset/mcp-atlassian/pull/1169) into community/main.

**Author:** CarlosBarrera-IAG (untrusted — security review required)

Adds `apk upgrade` to Docker final stage to pick up Alpine security patches (zlib CVEs).