### PR TITLE
fix(jira): resolve issue type IDs for all types on localized Jira instances

### DIFF
--- a/src/mcp_atlassian/jira/issues.py
+++ b/src/mcp_atlassian/jira/issues.py
@@ -605,7 +605,7 @@ class IssuesMixin(
                     "Provide issue_type like 'Task', 'Story', or 'Bug'."
                 )
 
-            # Handle Epic and Subtask issue type names across different languages
+            # Handle issue type names across different languages
             actual_issue_id = None
             if self._is_epic_issue_type(issue_type) and issue_type.lower() == "epic":
                 # If the user provided "Epic" but we need to find the localized name
@@ -620,6 +620,15 @@ class IssuesMixin(
                     actual_issue_id = subtask_type_id
                     logger.info(
                         f"Using localized Subtask issue type id: {subtask_type_id}"
+                    )
+            else:
+                # For all other issue types (Story, Task, Bug, etc.),
+                # resolve name to ID to support localized Jira instances
+                resolved_id = self._find_issue_type_id(project_key, issue_type)
+                if resolved_id:
+                    actual_issue_id = resolved_id
+                    logger.info(
+                        f"Resolved issue type '{issue_type}' to id: {resolved_id}"
                     )
 
             # Prepare fields
@@ -807,6 +816,39 @@ class IssuesMixin(
             return None
         except Exception as e:
             logger.warning(f"Could not get issue types for project {project_key}: {e}")
+            return None
+
+    def _find_issue_type_id(self, project_key: str, issue_type_name: str) -> str | None:
+        """
+        Find the issue type ID by name for a project.
+
+        Supports localized Jira instances where issue type names may differ
+        from the English defaults (e.g., Korean, Japanese, German).
+
+        Args:
+            project_key: The project key
+            issue_type_name: The issue type name to resolve
+
+        Returns:
+            The issue type ID if found, None otherwise
+        """
+        try:
+            issue_types = self.get_project_issue_types(project_key)
+            for issue_type in issue_types:
+                type_name = issue_type.get("name", "")
+                if type_name.lower() == issue_type_name.lower():
+                    return issue_type.get("id")
+            # Fallback: try untranslatedName if available
+            for issue_type in issue_types:
+                untranslated = issue_type.get("untranslatedName", "")
+                if untranslated and untranslated.lower() == issue_type_name.lower():
+                    return issue_type.get("id")
+            return None
+        except Exception as e:
+            logger.warning(
+                f"Could not resolve issue type '{issue_type_name}' "
+                f"for project {project_key}: {e}"
+            )
             return None
 
     def _prepare_epic_fields(

--- a/src/mcp_atlassian/jira/projects.py
+++ b/src/mcp_atlassian/jira/projects.py
@@ -260,6 +260,9 @@ class ProjectsMixin(JiraClient, SearchOperationsProto):
             # some API versions return "issueTypes" instead of "values"
             issue_types = meta.get("values", meta.get("issueTypes", []))
             if not issue_types:
+                # Fallback: atlassian-python-api returns "issueTypes" key
+                issue_types = meta.get("issueTypes", [])
+            if not issue_types:
                 # Fallback for older response format
                 projects = meta.get("projects", [])
                 if projects and "issuetypes" in projects[0]:

--- a/tests/unit/jira/test_issues.py
+++ b/tests/unit/jira/test_issues.py
@@ -1854,3 +1854,46 @@ class TestIssuesMixin:
         assert isinstance(result, JiraIssue)
         assert result.key == "DEV-123"
         assert result.summary == "Development issue"
+
+    def test_find_issue_type_id_exact_match(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id resolves type name to ID."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[
+                {"id": "10000", "name": "Bug"},
+                {"id": "10001", "name": "Story"},
+            ]
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "Bug") == "10000"
+        assert issues_mixin._find_issue_type_id("PROJ", "Story") == "10001"
+
+    def test_find_issue_type_id_case_insensitive(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id matches case-insensitively."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Story"}]
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "story") == "10001"
+        assert issues_mixin._find_issue_type_id("PROJ", "STORY") == "10001"
+
+    def test_find_issue_type_id_untranslated_fallback(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id falls back to untranslatedName for localized instances."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[
+                {"id": "10001", "name": "스토리", "untranslatedName": "Story"},
+            ]
+        )
+        # Korean name doesn't match "Story", but untranslatedName does
+        assert issues_mixin._find_issue_type_id("PROJ", "Story") == "10001"
+
+    def test_find_issue_type_id_not_found(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id returns None when type not found."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10000", "name": "Bug"}]
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "Nonexistent") is None
+
+    def test_find_issue_type_id_exception(self, issues_mixin: IssuesMixin):
+        """_find_issue_type_id returns None on exception."""
+        issues_mixin.get_project_issue_types = MagicMock(
+            side_effect=Exception("API error")
+        )
+        assert issues_mixin._find_issue_type_id("PROJ", "Bug") is None

--- a/tests/unit/jira/test_projects.py
+++ b/tests/unit/jira/test_projects.py
@@ -480,6 +480,20 @@ def test_get_project_issue_types_exception(projects_mixin: ProjectsMixin):
     projects_mixin.jira.issue_createmeta_issuetypes.assert_called_once()
 
 
+def test_get_project_issue_types_issue_types_key_fallback(
+    projects_mixin: ProjectsMixin, mock_issue_types: list[dict]
+):
+    """Test get_project_issue_types falls back to issueTypes key.
+
+    atlassian-python-api returns 'issueTypes' instead of 'values' in some cases.
+    """
+    createmeta = {"issueTypes": mock_issue_types}
+    projects_mixin.jira.issue_createmeta_issuetypes.return_value = createmeta
+
+    result = projects_mixin.get_project_issue_types("PROJ1")
+    assert result == mock_issue_types
+
+
 def test_get_project_issues_count(projects_mixin: ProjectsMixin):
     """Test get_project_issues_count method."""
     jql_result = {"total": 42}


### PR DESCRIPTION
Integrates [upstream PR #1170](https://github.com/sooperset/mcp-atlassian/pull/1170) into community/main.

**Author:** seongjinlim (untrusted — security review required)

Fixes create_issue on localized Jira instances where non-English issue type names caused failures. Adds tests not present in the original PR.