### PR TITLE
fix(confluence): rewrite bare-filename img tags as attachment macros (closes #169)

### DIFF
--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -1,6 +1,7 @@
 """Confluence-specific text preprocessing module."""
 
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -84,7 +85,7 @@ class ConfluencePreprocessor(BasePreprocessor):
                 # Convert the element tree back to a string
                 storage_format = elements_to_string(root)
 
-                return str(storage_format)
+                return self._fix_attachment_images(str(storage_format))
             finally:
                 # Clean up the temporary directory
                 shutil.rmtree(temp_dir, ignore_errors=True)
@@ -102,4 +103,37 @@ class ConfluencePreprocessor(BasePreprocessor):
 
             return str(storage_format)
 
-    # Confluence-specific methods can be added here
+    @staticmethod
+    def _fix_attachment_images(storage_html: str) -> str:
+        """Replace bare-filename ``<img>`` tags with Confluence attachment macros.
+
+        Confluence Storage Format cannot resolve bare filenames in
+        ``<img src="filename.ext"/>``. Attachment references must use the
+        ``ac:image`` / ``ri:attachment`` macro instead. External URLs
+        (``http``/``https``/``data``) and absolute paths are left untouched.
+
+        Args:
+            storage_html: Confluence storage format HTML string.
+
+        Returns:
+            Storage HTML with bare-filename img tags replaced by attachment macros.
+        """
+
+        def _replace(match: re.Match) -> str:  # type: ignore[type-arg]
+            tag = match.group(0)
+            src_match = re.search(r'src="([^"]+)"', tag)
+            alt_match = re.search(r'alt="([^"]+)"', tag)
+            if not src_match:
+                return tag
+            src = src_match.group(1)
+            # Leave external URLs and absolute paths untouched
+            if src.startswith(("http://", "https://", "data:", "/")):
+                return tag
+            alt = alt_match.group(1) if alt_match else ""
+            return (
+                f'<ac:image ac:alt="{alt}">'
+                f'<ri:attachment ri:filename="{src}"/>'
+                f"</ac:image>"
+            )
+
+        return re.sub(r"<img\b[^>]*/?>", _replace, storage_html)

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -592,6 +592,97 @@ More content.
     assert "<h2>" in result_with_anchors
 
 
+# Regression tests — bare-filename images produce "Preview unavailable"
+
+
+class TestFixAttachmentImages:
+    """Unit tests for ConfluencePreprocessor._fix_attachment_images."""
+
+    def setup_method(self):
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        self.fix = ConfluencePreprocessor._fix_attachment_images
+
+    def test_bare_filename_replaced_with_attachment_macro(self):
+        html = '<img src="chart.png" alt="Revenue chart"/>'
+        result = self.fix(html)
+        assert result == (
+            '<ac:image ac:alt="Revenue chart">'
+            '<ri:attachment ri:filename="chart.png"/>'
+            "</ac:image>"
+        )
+        assert "<img" not in result
+
+    def test_alt_text_preserved(self):
+        html = '<img alt="My diagram" src="diagram.svg"/>'
+        result = self.fix(html)
+        assert 'ac:alt="My diagram"' in result
+        assert 'ri:filename="diagram.svg"' in result
+
+    def test_missing_alt_defaults_to_empty_string(self):
+        html = '<img src="figure.png"/>'
+        result = self.fix(html)
+        assert 'ac:alt=""' in result
+        assert 'ri:filename="figure.png"' in result
+
+    def test_https_url_left_untouched(self):
+        html = '<img src="https://example.com/logo.png" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_http_url_left_untouched(self):
+        html = '<img src="http://example.com/img.jpg" alt="x"/>'
+        assert self.fix(html) == html
+
+    def test_data_uri_left_untouched(self):
+        html = '<img src="data:image/png;base64,abc123" alt="inline"/>'
+        assert self.fix(html) == html
+
+    def test_absolute_path_left_untouched(self):
+        html = '<img src="/images/logo.png" alt="logo"/>'
+        assert self.fix(html) == html
+
+    def test_mixed_content_only_bare_filenames_rewritten(self):
+        html = (
+            '<img src="local.png" alt="local"/>'
+            '<img src="https://cdn.example.com/remote.png" alt="remote"/>'
+        )
+        result = self.fix(html)
+        assert "ri:filename" in result
+        assert "https://cdn.example.com/remote.png" in result
+        assert '<img src="local.png"' not in result
+
+    def test_no_img_tags_unchanged(self):
+        html = "<p>No images here</p>"
+        assert self.fix(html) == html
+
+
+def test_markdown_to_confluence_storage_attachment_image():
+    """Regression: bare-filename images must produce ac:image attachment macros."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    result = preprocessor.markdown_to_confluence_storage("![Revenue chart](chart.png)")
+    assert "ri:filename" in result, (
+        "Expected Confluence attachment macro, got: " + result
+    )
+    assert 'ri:filename="chart.png"' in result
+    assert "<img" not in result, (
+        "Raw <img> tag found — will show as 'Preview unavailable'"
+    )
+
+
+def test_markdown_to_confluence_storage_external_image_unchanged():
+    """External image URLs must not be rewritten to attachment macros."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    result = preprocessor.markdown_to_confluence_storage(
+        "![Logo](https://example.com/logo.png)"
+    )
+    assert "https://example.com/logo.png" in result
+    assert 'ri:filename="https://example.com/logo.png"' not in result
+
+
 # Issue #786 regression tests - Wiki Markup Corruption
 
 


### PR DESCRIPTION
## Summary

Integrates upstream PR [sooperset/mcp-atlassian#1176](https://github.com/sooperset/mcp-atlassian/pull/1176) as-is.

- Bare-filename images in markdown (e.g. `![chart](chart.png)`) were silently emitted as raw `<img>` tags, which Confluence can't resolve — shows "Preview unavailable"
- Post-processes storage HTML to replace bare-filename `<img>` tags with `ac:image`/`ri:attachment` macros
- External URLs (http/https/data) and absolute paths left untouched
- 11 new tests (9 unit + 2 end-to-end regression)

## Test plan

- [x] 11 new tests pass
- [x] Full suite: 2814 passed, 0 failures, 0 warnings
- [x] Pre-commit clean (ruff, ruff-format, mypy)
- [x] Security review: pure string transformation, no network/file/credential access

Closes #169

Closes #271