### PR TITLE
feat(confluence): table layout, page width, restrictions, and copy page (closes #171)

### DIFF
--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -10,6 +10,7 @@ from .comments import CommentsMixin
 from .config import ConfluenceConfig
 from .labels import LabelsMixin
 from .pages import PagesMixin
+from .restrictions import RestrictionsMixin
 from .search import SearchMixin
 from .spaces import SpacesMixin
 from .users import UsersMixin
@@ -24,6 +25,7 @@ class ConfluenceFetcher(
     UsersMixin,
     AnalyticsMixin,
     AttachmentsMixin,
+    RestrictionsMixin,
 ):
     """Main entry point for Confluence operations, providing backward compatibility.
 

--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -590,6 +590,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Create a new page in a Confluence space.
@@ -604,6 +605,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only)
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only)
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the new page's data
@@ -616,7 +618,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -685,6 +689,7 @@ class PagesMixin(ConfluenceClient):
         content_representation: str | None = None,
         emoji: str | None = None,
         page_width: str | None = None,
+        table_layout: str | None = None,
     ) -> ConfluencePage:
         """
         Update an existing page in Confluence.
@@ -701,6 +706,7 @@ class PagesMixin(ConfluenceClient):
             content_representation: Content format when is_markdown=False ('wiki' or 'storage', keyword-only)
             emoji: Optional emoji character for the page title icon (keyword-only). Pass empty string to remove emoji.
             page_width: Optional page layout width ('full-width', 'max', or 'default', keyword-only). Pass empty string to reset to default.
+            table_layout: Optional table width preset for markdown tables ('full-width', 'wide', 'default', keyword-only)
 
         Returns:
             ConfluencePage model containing the updated page's data
@@ -713,7 +719,9 @@ class PagesMixin(ConfluenceClient):
             if is_markdown:
                 # Convert markdown to Confluence storage format
                 final_body = self.preprocessor.markdown_to_confluence_storage(
-                    body, enable_heading_anchors=enable_heading_anchors
+                    body,
+                    enable_heading_anchors=enable_heading_anchors,
+                    table_layout=table_layout,
                 )
                 representation = "storage"
             else:
@@ -1385,3 +1393,79 @@ class PagesMixin(ConfluenceClient):
             "to_version": to_version,
             "diff": diff_string,
         }
+
+    @handle_auth_errors("Confluence API")
+    def copy_page(
+        self,
+        source_page_id: str,
+        destination_space_key: str,
+        new_title: str,
+        destination_parent_id: str | None = None,
+        *,
+        copy_attachments: bool = True,
+    ) -> ConfluencePage:
+        """Copy a Confluence page to a new location.
+
+        On Confluence Cloud the native copy endpoint is used
+        (``POST /wiki/rest/api/content/{id}/copy``).  On Server/Data Center
+        the page body and title are fetched and a new page is created manually
+        (attachments are not copied in the Server/DC fallback path).
+
+        Args:
+            source_page_id: The ID of the page to copy.
+            destination_space_key: Space key for the new page.
+            new_title: Title of the new page.
+            destination_parent_id: Optional parent page ID in the destination space.
+                When omitted the new page is created at the space root.
+            copy_attachments: Whether to copy attachments (Cloud only, keyword-only).
+
+        Returns:
+            ConfluencePage model for the newly created copy.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the copy operation fails.
+        """
+        try:
+            if self.config.is_cloud:
+                payload: dict[str, object] = {
+                    "copyAttachments": copy_attachments,
+                    "copyPermissions": False,
+                    "copyProperties": False,
+                    "copyLabels": False,
+                    "pageTitle": new_title,
+                    "destination": {
+                        "type": "parent_page" if destination_parent_id else "space",
+                        "value": destination_parent_id or destination_space_key,
+                    },
+                }
+                result = self.confluence.post(
+                    f"rest/api/content/{source_page_id}/copy",
+                    data=payload,
+                )
+            else:
+                # Server/DC: manual GET + POST (no native copy endpoint)
+                source = self.confluence.get_page_by_id(
+                    source_page_id, expand="body.storage,version,space"
+                )
+                body = source.get("body", {}).get("storage", {}).get("value", "")
+                create_kwargs: dict[str, object] = {
+                    "space": destination_space_key,
+                    "title": new_title,
+                    "body": body,
+                    "representation": "storage",
+                }
+                if destination_parent_id:
+                    create_kwargs["parent_id"] = destination_parent_id
+                result = self.confluence.create_page(**create_kwargs)
+
+            new_page_id = result.get("id")
+            if not new_page_id:
+                raise ValueError("Copy response did not contain a page ID")
+
+            return self.get_page_content(new_page_id)
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error copying page {source_page_id}: {str(e)}")
+            raise Exception(f"Failed to copy page {source_page_id}: {str(e)}") from e

--- a/src/mcp_atlassian/confluence/restrictions.py
+++ b/src/mcp_atlassian/confluence/restrictions.py
@@ -1,0 +1,167 @@
+"""Module for Confluence page restriction operations."""
+
+import json
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..utils.decorators import handle_auth_errors
+from .client import ConfluenceClient
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+class RestrictionsMixin(ConfluenceClient):
+    """Mixin for Confluence page restriction operations."""
+
+    @handle_auth_errors("Confluence API")
+    def get_page_restrictions(self, page_id: str) -> dict[str, Any]:
+        """Get view and edit restrictions for a Confluence page.
+
+        Returns the current restriction lists for the ``read`` and ``update``
+        operations.  An empty list for an operation means the page is
+        unrestricted for that operation (visible/editable by everyone).
+
+        Args:
+            page_id: The ID of the page to query.
+
+        Returns:
+            Dict with ``read`` and ``update`` keys, each containing:
+            ``{"users": [...account_ids...], "groups": [...group_names...]}``
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            data = self.confluence.get_all_restrictions_for_content(page_id)
+
+            result: dict[str, Any] = {
+                "read": {"users": [], "groups": []},
+                "update": {"users": [], "groups": []},
+            }
+
+            if not isinstance(data, dict):
+                return result
+
+            for operation, op_key in (("read", "read"), ("update", "update")):
+                op_data = data.get(operation, {})
+                if not isinstance(op_data, dict):
+                    continue
+
+                restrictions = op_data.get("restrictions", {})
+                if not isinstance(restrictions, dict):
+                    continue
+
+                users = restrictions.get("user", {})
+                if isinstance(users, dict):
+                    for u in users.get("results", []):
+                        account_id = (
+                            u.get("accountId") or u.get("username") or u.get("name")
+                        )
+                        if account_id:
+                            result[op_key]["users"].append(account_id)
+
+                groups = restrictions.get("group", {})
+                if isinstance(groups, dict):
+                    for g in groups.get("results", []):
+                        group_name = g.get("name")
+                        if group_name:
+                            result[op_key]["groups"].append(group_name)
+
+            return result
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error fetching restrictions for page {page_id}: {str(e)}")
+            raise Exception(
+                f"Failed to get restrictions for page {page_id}: {str(e)}"
+            ) from e
+
+    @handle_auth_errors("Confluence API")
+    def set_page_restrictions(
+        self,
+        page_id: str,
+        *,
+        read_users: list[str] | None = None,
+        read_groups: list[str] | None = None,
+        edit_users: list[str] | None = None,
+        edit_groups: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Set view and edit restrictions on a Confluence page.
+
+        Replaces all existing restrictions with the provided lists.
+        Passing empty lists for all parameters removes all restrictions
+        (makes the page unrestricted).
+
+        Confluence uses ``read`` for view access and ``update`` for edit
+        access.  Users are identified by account ID (Cloud) or username
+        (Server/DC); groups by group name.
+
+        Args:
+            page_id: The ID of the page to restrict.
+            read_users: Account IDs (Cloud) / usernames (Server/DC) that may view the page.
+            read_groups: Group names that may view the page.
+            edit_users: Account IDs / usernames that may edit the page.
+            edit_groups: Group names that may edit the page.
+
+        Returns:
+            Dict with the updated ``read`` and ``update`` restriction lists,
+            in the same format as :meth:`get_page_restrictions`.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            read_users = read_users or []
+            read_groups = read_groups or []
+            edit_users = edit_users or []
+            edit_groups = edit_groups or []
+
+            def _user_entry(account_id: str) -> dict[str, str]:
+                # Cloud uses accountId; Server/DC uses name/username
+                if self.config.is_cloud:
+                    return {"type": "known", "accountId": account_id}
+                return {"type": "known", "username": account_id}
+
+            def _group_entry(name: str) -> dict[str, str]:
+                return {"type": "group", "name": name}
+
+            payload = [
+                {
+                    "operation": "read",
+                    "restrictions": {
+                        "user": [_user_entry(u) for u in read_users],
+                        "group": [_group_entry(g) for g in read_groups],
+                    },
+                },
+                {
+                    "operation": "update",
+                    "restrictions": {
+                        "user": [_user_entry(u) for u in edit_users],
+                        "group": [_group_entry(g) for g in edit_groups],
+                    },
+                },
+            ]
+
+            # The atlassian library's put() only accepts dict|str for data;
+            # the restrictions endpoint expects a JSON array, so serialise manually.
+            self.confluence.put(
+                f"rest/api/content/{page_id}/restriction",
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+            )
+
+            return {
+                "read": {"users": read_users, "groups": read_groups},
+                "update": {"users": edit_users, "groups": edit_groups},
+            }
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error setting restrictions for page {page_id}: {str(e)}")
+            raise Exception(
+                f"Failed to set restrictions for page {page_id}: {str(e)}"
+            ) from e

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -37,8 +37,24 @@ class ConfluencePreprocessor(BasePreprocessor):
         """
         super().__init__(base_url=base_url)
 
+    # Table width (px) and layout name keyed by the caller-supplied table_layout value.
+    _TABLE_WIDTHS: dict[str, str] = {
+        "full-width": "1800",
+        "wide": "960",
+        "default": "760",
+    }
+    _TABLE_LAYOUTS: dict[str, str] = {
+        "full-width": "full-width",
+        "wide": "wide",
+        "default": "default",
+    }
+
     def markdown_to_confluence_storage(
-        self, markdown_content: str, *, enable_heading_anchors: bool = False
+        self,
+        markdown_content: str,
+        *,
+        enable_heading_anchors: bool = False,
+        table_layout: str | None = None,
     ) -> str:
         """
         Convert Markdown content to Confluence storage format (XHTML)
@@ -46,6 +62,9 @@ class ConfluencePreprocessor(BasePreprocessor):
         Args:
             markdown_content: Markdown text to convert
             enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False)
+            table_layout: Optional table width preset applied to all tables in the output.
+                Values: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px / Confluence default).
+                When None, tables retain the default 760 px width emitted by the converter.
 
         Returns:
             Confluence storage format (XHTML) string
@@ -83,9 +102,14 @@ class ConfluencePreprocessor(BasePreprocessor):
                 converter.visit(root)
 
                 # Convert the element tree back to a string
-                storage_format = elements_to_string(root)
+                storage_format = str(elements_to_string(root))
 
-                return self._fix_attachment_images(str(storage_format))
+                if table_layout and table_layout in self._TABLE_WIDTHS:
+                    storage_format = self._apply_table_layout(
+                        storage_format, table_layout
+                    )
+
+                return self._fix_attachment_images(storage_format)
             finally:
                 # Clean up the temporary directory
                 shutil.rmtree(temp_dir, ignore_errors=True)
@@ -97,7 +121,6 @@ class ConfluencePreprocessor(BasePreprocessor):
             # Fall back to a simpler method if the conversion fails
             html_content = markdown_to_html(markdown_content)
 
-            # Use a different approach that doesn't rely on the HTML macro
             # This creates a proper Confluence storage format document
             storage_format = f"""<p>{html_content}</p>"""
 
@@ -137,3 +160,36 @@ class ConfluencePreprocessor(BasePreprocessor):
             )
 
         return re.sub(r"<img\b[^>]*/?>", _replace, storage_html)
+
+    @classmethod
+    def _apply_table_layout(cls, storage_html: str, table_layout: str) -> str:
+        """Set table width and layout attributes in Confluence storage format.
+
+        The md2conf converter emits bare ``<table>`` tags with no width or
+        layout attributes.  Confluence renders these at its default narrow
+        width.  This method injects ``data-table-width`` and ``data-layout``
+        attributes so tables render at the requested width.
+
+        If attributes already exist (e.g. content edited via another tool)
+        they are replaced rather than duplicated.
+
+        Args:
+            storage_html: Confluence storage-format string to post-process.
+            table_layout: One of 'full-width', 'wide', or 'default'.
+
+        Returns:
+            Updated storage-format string with table width attributes set.
+        """
+        width = cls._TABLE_WIDTHS.get(table_layout, "760")
+        layout = cls._TABLE_LAYOUTS.get(table_layout, "default")
+        attrs = f'data-table-width="{width}" data-layout="{layout}"'
+
+        def _replace_table_tag(m: re.Match) -> str:
+            tag = m.group(0)
+            # Strip any existing data-table-width / data-layout attributes first
+            tag = re.sub(r'\s*data-table-width="[^"]*"', "", tag)
+            tag = re.sub(r'\s*data-layout="[^"]*"', "", tag)
+            # Inject new attributes after <table
+            return re.sub(r"^<table", f"<table {attrs}", tag)
+
+        return re.sub(r"<table\b[^>]*>", _replace_table_tag, storage_html)

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -641,6 +641,20 @@ async def create_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (Confluence default).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Create a new Confluence page.
 
@@ -654,6 +668,8 @@ async def create_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the created page object.
@@ -688,6 +704,8 @@ async def create_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     result = page.to_simplified_dict()
     if not include_content:
@@ -753,6 +771,20 @@ async def update_page(
             default=None,
         ),
     ] = None,
+    page_width: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Page layout width. Options: 'full-width', 'default'. Defaults to null (preserve existing).",
+            default=None,
+        ),
+    ] = None,
+    table_layout: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Table width preset applied to all markdown tables. Options: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px). Only applies when content_format is 'markdown'.",
+            default=None,
+        ),
+    ] = None,
 ) -> str:
     """Update an existing Confluence page.
 
@@ -768,6 +800,8 @@ async def update_page(
         enable_heading_anchors: Whether to enable heading anchors (markdown only).
         include_content: Whether to include page content in the response.
         emoji: Optional page title emoji (icon shown in navigation).
+        page_width: Optional page layout width ('full-width' or 'default').
+        table_layout: Optional table width preset ('full-width', 'wide', 'default').
 
     Returns:
         JSON string representing the updated page object.
@@ -804,6 +838,8 @@ async def update_page(
         else False,
         content_representation=content_representation,
         emoji=emoji,
+        page_width=page_width,
+        table_layout=table_layout if content_format == "markdown" else None,
     )
     page_data = updated_page.to_simplified_dict()
     if not include_content:
@@ -2494,3 +2530,167 @@ async def set_content_property(
     confluence_fetcher = await get_confluence_fetcher(ctx)
     result = confluence_fetcher.set_content_property(page_id, key, parsed_value)
     return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_pages"},
+    annotations={"title": "Get Page Restrictions", "readOnlyHint": True},
+)
+async def get_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page")],
+) -> str:
+    """Get view and edit restrictions for a Confluence page.
+
+    Returns the current restriction lists for the read (view) and update (edit)
+    operations.  An empty list means the page is unrestricted for that operation.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page.
+
+    Returns:
+        JSON string with ``read`` and ``update`` restriction lists, each
+        containing ``users`` (account IDs) and ``groups`` (group names).
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    restrictions = confluence_fetcher.get_page_restrictions(page_id=page_id)
+    return json.dumps(restrictions, indent=2, ensure_ascii=False)
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Set Page Restrictions", "destructiveHint": True},
+)
+@check_write_access
+async def set_page_restrictions(
+    ctx: Context,
+    page_id: Annotated[str, Field(description="The ID of the page to restrict")],
+    read_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to view the page. Empty list = unrestricted.",
+            default=None,
+        ),
+    ] = None,
+    read_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to view the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_users: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Account IDs (Cloud) or usernames (Server/DC) allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+    edit_groups: Annotated[
+        list[str] | None,
+        Field(
+            description="(Optional) Group names allowed to edit the page.",
+            default=None,
+        ),
+    ] = None,
+) -> str:
+    """Set view and edit restrictions on a Confluence page.
+
+    Replaces all existing restrictions with the provided lists.  Omitting all
+    parameters (or passing empty lists) removes all restrictions.
+
+    Args:
+        ctx: The FastMCP context.
+        page_id: The ID of the page to restrict.
+        read_users: Account IDs / usernames allowed to view the page.
+        read_groups: Group names allowed to view the page.
+        edit_users: Account IDs / usernames allowed to edit the page.
+        edit_groups: Group names allowed to edit the page.
+
+    Returns:
+        JSON string with the updated restriction lists.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    result = confluence_fetcher.set_page_restrictions(
+        page_id=page_id,
+        read_users=read_users,
+        read_groups=read_groups,
+        edit_users=edit_users,
+        edit_groups=edit_groups,
+    )
+    return json.dumps(
+        {"message": "Page restrictions updated successfully", "restrictions": result},
+        indent=2,
+        ensure_ascii=False,
+    )
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_pages"},
+    annotations={"title": "Copy Page", "destructiveHint": True},
+)
+@check_write_access
+async def copy_page(
+    ctx: Context,
+    source_page_id: Annotated[str, Field(description="The ID of the page to copy")],
+    destination_space_key: Annotated[
+        str,
+        Field(description="Space key for the new page (e.g. 'DEV', 'TEAM')"),
+    ],
+    new_title: Annotated[str, Field(description="Title for the new copied page")],
+    destination_parent_id: Annotated[
+        str | None,
+        Field(
+            description="(Optional) Parent page ID in the destination space. When omitted the page is created at the space root.",
+            default=None,
+        ),
+        BeforeValidator(lambda x: str(x) if x is not None else None),
+    ] = None,
+    copy_attachments: Annotated[
+        bool,
+        Field(
+            description="(Optional) Whether to copy attachments to the new page. Defaults to true. Only supported on Confluence Cloud.",
+            default=True,
+        ),
+    ] = True,
+) -> str:
+    """Copy a Confluence page to a new location.
+
+    On Confluence Cloud the native copy endpoint is used.  On Server/Data Center
+    the page body is fetched and a new page is created manually (attachments are
+    not copied in the Server/DC path).
+
+    Args:
+        ctx: The FastMCP context.
+        source_page_id: The ID of the page to copy.
+        destination_space_key: Space key for the new page.
+        new_title: Title for the new copied page.
+        destination_parent_id: Optional parent page ID in the destination space.
+        copy_attachments: Whether to copy attachments (Cloud only).
+
+    Returns:
+        JSON string representing the new page.
+
+    Raises:
+        ValueError: If Confluence client is not configured or available.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+    page = confluence_fetcher.copy_page(
+        source_page_id=source_page_id,
+        destination_space_key=destination_space_key,
+        new_title=new_title,
+        destination_parent_id=destination_parent_id,
+        copy_attachments=copy_attachments,
+    )
+    return json.dumps(
+        {"message": "Page copied successfully", "page": page.to_simplified_dict()},
+        indent=2,
+        ensure_ascii=False,
+    )

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -788,7 +788,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify create_page was called with the converted content
@@ -875,7 +875,7 @@ class TestPagesMixin:
             # Assert
             # Verify markdown was converted
             pages_mixin.preprocessor.markdown_to_confluence_storage.assert_called_once_with(
-                markdown_body, enable_heading_anchors=False
+                markdown_body, enable_heading_anchors=False, table_layout=None
             )
 
             # Verify update_page was called with the converted content

--- a/tests/unit/confluence/test_restrictions.py
+++ b/tests/unit/confluence/test_restrictions.py
@@ -1,0 +1,169 @@
+"""Unit tests for Confluence page restriction operations."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.confluence.restrictions import RestrictionsMixin
+
+
+@pytest.fixture
+def restrictions_mixin(confluence_client):
+    """Return a RestrictionsMixin with a mocked Confluence client."""
+    with patch(
+        "mcp_atlassian.confluence.restrictions.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = RestrictionsMixin()
+        mixin.confluence = confluence_client.confluence
+        mixin.config = confluence_client.config
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+@pytest.fixture
+def restrictions_mixin_server_dc(confluence_client):
+    """Return a RestrictionsMixin configured as Server/DC."""
+    with patch(
+        "mcp_atlassian.confluence.restrictions.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = RestrictionsMixin()
+        mixin.confluence = confluence_client.confluence
+        # Use a MagicMock config so is_cloud can be set freely
+        mixin.config = MagicMock()
+        mixin.config.is_cloud = False
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+class TestGetPageRestrictions:
+    def test_get_restrictions_parses_users_and_groups(self, restrictions_mixin):
+        """get_page_restrictions extracts user account IDs and group names."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {
+            "read": {
+                "restrictions": {
+                    "user": {
+                        "results": [
+                            {"accountId": "user-111"},
+                            {"accountId": "user-222"},
+                        ]
+                    },
+                    "group": {
+                        "results": [
+                            {"name": "developers"},
+                        ]
+                    },
+                }
+            },
+            "update": {
+                "restrictions": {
+                    "user": {"results": [{"accountId": "user-111"}]},
+                    "group": {"results": []},
+                }
+            },
+        }
+
+        result = restrictions_mixin.get_page_restrictions("123")
+
+        assert result["read"]["users"] == ["user-111", "user-222"]
+        assert result["read"]["groups"] == ["developers"]
+        assert result["update"]["users"] == ["user-111"]
+        assert result["update"]["groups"] == []
+
+    def test_get_restrictions_empty_response(self, restrictions_mixin):
+        """get_page_restrictions handles an empty / unrestricted page gracefully."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.return_value = {}
+
+        result = restrictions_mixin.get_page_restrictions("456")
+
+        assert result == {
+            "read": {"users": [], "groups": []},
+            "update": {"users": [], "groups": []},
+        }
+
+    def test_get_restrictions_api_error(self, restrictions_mixin):
+        """get_page_restrictions raises on API failure."""
+        restrictions_mixin.confluence.get_all_restrictions_for_content.side_effect = (
+            Exception("API error")
+        )
+
+        with pytest.raises(Exception, match="Failed to get restrictions for page 789"):
+            restrictions_mixin.get_page_restrictions("789")
+
+
+class TestSetPageRestrictions:
+    def test_set_restrictions_calls_put_with_correct_payload(self, restrictions_mixin):
+        """set_page_restrictions sends a correctly structured PUT payload."""
+        restrictions_mixin.confluence.put = MagicMock()
+
+        result = restrictions_mixin.set_page_restrictions(
+            "123",
+            read_users=["user-aaa"],
+            read_groups=["viewers"],
+            edit_users=["user-bbb"],
+            edit_groups=["editors"],
+        )
+
+        call_args = restrictions_mixin.confluence.put.call_args
+        assert call_args[0][0] == "rest/api/content/123/restriction"
+        # data is serialised as a JSON string
+        import json as _json
+
+        payload = _json.loads(call_args[1]["data"])
+
+        read_op = next(o for o in payload if o["operation"] == "read")
+        update_op = next(o for o in payload if o["operation"] == "update")
+
+        assert read_op["restrictions"]["user"][0]["accountId"] == "user-aaa"
+        assert read_op["restrictions"]["group"][0]["name"] == "viewers"
+        assert update_op["restrictions"]["user"][0]["accountId"] == "user-bbb"
+        assert update_op["restrictions"]["group"][0]["name"] == "editors"
+
+        assert result["read"]["users"] == ["user-aaa"]
+        assert result["update"]["groups"] == ["editors"]
+
+    def test_set_restrictions_empty_clears_all(self, restrictions_mixin):
+        """set_page_restrictions with no args sends empty restriction lists."""
+        import json as _json
+
+        restrictions_mixin.confluence.put = MagicMock()
+
+        result = restrictions_mixin.set_page_restrictions("123")
+
+        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        for op in payload:
+            assert op["restrictions"]["user"] == []
+            assert op["restrictions"]["group"] == []
+
+        assert result == {
+            "read": {"users": [], "groups": []},
+            "update": {"users": [], "groups": []},
+        }
+
+    def test_set_restrictions_server_dc_uses_username(
+        self, restrictions_mixin_server_dc
+    ):
+        """set_page_restrictions uses 'username' key for Server/DC instances."""
+        import json as _json
+
+        restrictions_mixin = restrictions_mixin_server_dc
+        restrictions_mixin.confluence.put = MagicMock()
+
+        restrictions_mixin.set_page_restrictions("123", edit_users=["jdoe"])
+
+        payload = _json.loads(restrictions_mixin.confluence.put.call_args[1]["data"])
+        update_op = next(o for o in payload if o["operation"] == "update")
+        user_entry = update_op["restrictions"]["user"][0]
+        assert "username" in user_entry
+        assert "accountId" not in user_entry
+        assert user_entry["username"] == "jdoe"
+
+    def test_set_restrictions_api_error(self, restrictions_mixin):
+        """set_page_restrictions raises on PUT failure."""
+        restrictions_mixin.confluence.put = MagicMock(
+            side_effect=Exception("network error")
+        )
+
+        with pytest.raises(Exception, match="Failed to set restrictions for page 999"):
+            restrictions_mixin.set_page_restrictions("999", read_users=["u1"])

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -765,6 +765,73 @@ def function_{i}():
         assert "😀" in processed_markdown  # Emoji from numeric entity
 
 
+class TestTableLayout:
+    """Tests for table_layout post-processing in markdown_to_confluence_storage."""
+
+    MARKDOWN_WITH_TABLE = "| A | B |\n|---|---|\n| 1 | 2 |"
+
+    def test_table_layout_full_width(self, confluence_preprocessor):
+        """table_layout='full-width' sets data-table-width=1800 and data-layout=full-width."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="full-width"
+        )
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+
+    def test_table_layout_wide(self, confluence_preprocessor):
+        """table_layout='wide' sets data-table-width=960 and data-layout=wide."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="wide"
+        )
+        assert 'data-table-width="960"' in result
+        assert 'data-layout="wide"' in result
+
+    def test_table_layout_default(self, confluence_preprocessor):
+        """table_layout='default' adds 760 px width attribute."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="default"
+        )
+        assert 'data-table-width="760"' in result
+        assert 'data-layout="default"' in result
+
+    def test_table_layout_none_emits_bare_table(self, confluence_preprocessor):
+        """Omitting table_layout leaves the converter's bare <table> tag unchanged."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE
+        )
+        # md2conf produces a bare <table> with no width attributes
+        assert "data-table-width" not in result
+
+    def test_table_layout_unknown_value_is_ignored(self, confluence_preprocessor):
+        """An unrecognised table_layout value does not add width attributes."""
+        result = confluence_preprocessor.markdown_to_confluence_storage(
+            self.MARKDOWN_WITH_TABLE, table_layout="ultra-wide"
+        )
+        # Unrecognised value: no post-processing applied
+        assert "data-table-width" not in result
+
+    def test_apply_table_layout_injects_attrs_on_bare_tables(
+        self, confluence_preprocessor
+    ):
+        """_apply_table_layout adds attributes to bare <table> tags."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = "<table><tr><td>A</td></tr></table><table><tr><td>B</td></tr></table>"
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert result.count('data-table-width="1800"') == 2
+        assert result.count('data-layout="full-width"') == 2
+
+    def test_apply_table_layout_replaces_existing_attrs(self, confluence_preprocessor):
+        """_apply_table_layout replaces existing data-table-width/layout attrs."""
+        from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+        html = '<table data-table-width="760" data-layout="default"><tr><td>X</td></tr></table>'
+        result = ConfluencePreprocessor._apply_table_layout(html, "full-width")
+        assert 'data-table-width="1800"' in result
+        assert 'data-layout="full-width"' in result
+        assert 'data-table-width="760"' not in result
+
+
 class TestContentProcessingInteroperability:
     """Test interoperability between Jira and Confluence content processing."""
 

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 29, (
-            f"Expected 29 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 32, (
+            f"Expected 32 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
## Summary

Integrates upstream PR [sooperset/mcp-atlassian#1178](https://github.com/sooperset/mcp-atlassian/pull/1178) — 5 features in one PR.

- **page_width param** on `create_page`/`update_page` tools — exposes existing mixin-level param that was missing from the tool layer
- **table_layout param** + `_apply_table_layout` post-processor — injects `data-table-width`/`data-layout` attrs so markdown tables render at full-width/wide/default instead of hardcoded 760px
- **RestrictionsMixin** — `get_page_restrictions` and `set_page_restrictions` with Cloud (accountId) and Server/DC (username) support
- **copy_page** — native Cloud endpoint, manual GET+POST fallback for Server/DC
- **+3 new tools** (get_restrictions, set_restrictions, copy_page), +2 params on existing tools (page_width, table_layout)

### Phase C alignment

| Feature | Assessment |
|---------|------------|
| page_width/table_layout | Params on existing tools — exactly what Phase C wants |
| Restrictions (get/set) | Distinct domain from page content — standalone tools appropriate |
| Copy page | Phase C explicitly says "may warrant its own tool" |

## Test plan

- [x] 22 new tests (7 restrictions, 7 table layout, 2 page test updates, + existing)
- [x] Full suite: 2843 passed, 0 failures, 0 warnings (`-W error`)
- [x] Pre-commit clean (ruff, ruff-format, mypy)
- [x] Security review: library methods only, `@handle_auth_errors` + `@check_write_access` applied, no credential/file/exec access
- [x] Conflict resolution: merged with our #1174 (content properties) and #1176 (attachment images) cleanly

Closes #171

Closes #272