### PR TITLE
feat(confluence): GFM task list conversion and page template tools (closes #173)

### DIFF
--- a/src/mcp_atlassian/confluence/__init__.py
+++ b/src/mcp_atlassian/confluence/__init__.py
@@ -13,6 +13,7 @@ from .pages import PagesMixin
 from .restrictions import RestrictionsMixin
 from .search import SearchMixin
 from .spaces import SpacesMixin
+from .templates import TemplatesMixin
 from .users import UsersMixin
 
 
@@ -26,6 +27,7 @@ class ConfluenceFetcher(
     AnalyticsMixin,
     AttachmentsMixin,
     RestrictionsMixin,
+    TemplatesMixin,
 ):
     """Main entry point for Confluence operations, providing backward compatibility.
 
@@ -41,6 +43,8 @@ class ConfluenceFetcher(
     - UsersMixin: User operations
     - AnalyticsMixin: Page view analytics (Cloud only)
     - AttachmentsMixin: Attachment operations
+    - RestrictionsMixin: Page restriction operations
+    - TemplatesMixin: Template operations
     """
 
     pass

--- a/src/mcp_atlassian/confluence/templates.py
+++ b/src/mcp_atlassian/confluence/templates.py
@@ -1,0 +1,134 @@
+"""Module for Confluence template operations."""
+
+import logging
+from typing import Any
+
+from requests.exceptions import HTTPError
+
+from ..utils.decorators import handle_auth_errors
+from .client import ConfluenceClient
+
+logger = logging.getLogger("mcp-atlassian")
+
+
+class TemplatesMixin(ConfluenceClient):
+    """Mixin for Confluence template operations."""
+
+    @handle_auth_errors("Confluence API")
+    def list_page_templates(
+        self,
+        space_key: str | None = None,
+        limit: int = 25,
+    ) -> list[dict[str, Any]]:
+        """List page content templates, optionally scoped to a space.
+
+        When ``space_key`` is omitted, global templates are returned.  Pass a
+        space key to retrieve templates defined within that space.
+
+        Args:
+            space_key: Optional space key to filter templates.  ``None``
+                returns global templates.
+            limit: Maximum number of templates to return (default 25).
+
+        Returns:
+            List of template dicts, each containing at minimum:
+            ``templateId``, ``name``, ``templateType``, and ``description``.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails.
+        """
+        try:
+            results: list[dict[str, Any]] = self.confluence.get_content_templates(
+                space=space_key,
+                limit=limit,
+            )
+            return results
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error listing templates: {str(e)}")
+            raise Exception(f"Failed to list page templates: {str(e)}") from e
+
+    @handle_auth_errors("Confluence API")
+    def get_page_template(self, template_id: str) -> dict[str, Any]:
+        """Get a single content template by ID, including its body.
+
+        Args:
+            template_id: The ID of the template to retrieve.
+
+        Returns:
+            Template dict containing ``templateId``, ``name``,
+            ``templateType``, ``description``, and ``body`` (storage format).
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the API call fails or the template is not found.
+        """
+        try:
+            return self.confluence.get_content_template(template_id)  # type: ignore[no-any-return]
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error fetching template {template_id}: {str(e)}")
+            raise Exception(f"Failed to get template {template_id}: {str(e)}") from e
+
+    @handle_auth_errors("Confluence API")
+    def create_page_from_template(
+        self,
+        space_key: str,
+        title: str,
+        template_id: str,
+        parent_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new Confluence page pre-populated with a template's body.
+
+        Fetches the template's storage-format body and creates a page with
+        that content.  The caller can rename the page and edit it afterwards.
+
+        Args:
+            space_key: Key of the space in which to create the page.
+            title: Title for the new page.
+            template_id: ID of the template whose body to use.
+            parent_id: Optional parent page ID.
+
+        Returns:
+            Dict with ``id``, ``title``, ``url``, and ``space_key`` of the
+            newly created page.
+
+        Raises:
+            MCPAtlassianAuthenticationError: If authentication fails.
+            Exception: If the template fetch or page creation fails.
+        """
+        try:
+            template = self.confluence.get_content_template(template_id)
+
+            body_obj = template.get("body", {})
+            # Templates store content under body.storage.value (same as pages)
+            body_value: str = body_obj.get("storage", {}).get("value", "")
+
+            result = self.confluence.create_page(
+                space=space_key,
+                title=title,
+                body=body_value,
+                parent_id=parent_id,
+                representation="storage",
+            )
+
+            page_id: str = result.get("id", "")
+            base_url = self.config.url.rstrip("/")
+            page_url = f"{base_url}/wiki/spaces/{space_key}/pages/{page_id}"
+
+            return {
+                "id": page_id,
+                "title": result.get("title", title),
+                "url": page_url,
+                "space_key": space_key,
+            }
+        except HTTPError:
+            raise
+        except Exception as e:
+            logger.error(f"Error creating page from template {template_id}: {str(e)}")
+            raise Exception(
+                f"Failed to create page from template {template_id}: {str(e)}"
+            ) from e

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -55,16 +55,21 @@ class ConfluencePreprocessor(BasePreprocessor):
         *,
         enable_heading_anchors: bool = False,
         table_layout: str | None = None,
+        apply_task_lists: bool = True,
     ) -> str:
         """
         Convert Markdown content to Confluence storage format (XHTML)
 
         Args:
             markdown_content: Markdown text to convert
-            enable_heading_anchors: Whether to enable automatic heading anchor generation (default: False)
+            enable_heading_anchors: Whether to enable automatic heading anchor
+                generation (default: False)
             table_layout: Optional table width preset applied to all tables in the output.
                 Values: 'full-width' (1800 px), 'wide' (960 px), 'default' (760 px / Confluence default).
                 When None, tables retain the default 760 px width emitted by the converter.
+            apply_task_lists: Whether to convert GFM task-list items
+                (``- [ ]`` / ``- [x]``) to Confluence ``ac:task-list`` macros
+                (default: True)
 
         Returns:
             Confluence storage format (XHTML) string
@@ -108,6 +113,9 @@ class ConfluencePreprocessor(BasePreprocessor):
                     storage_format = self._apply_table_layout(
                         storage_format, table_layout
                     )
+
+                if apply_task_lists:
+                    storage_format = self._apply_task_lists(storage_format)
 
                 return self._fix_attachment_images(storage_format)
             finally:
@@ -193,3 +201,55 @@ class ConfluencePreprocessor(BasePreprocessor):
             return re.sub(r"^<table", f"<table {attrs}", tag)
 
         return re.sub(r"<table\b[^>]*>", _replace_table_tag, storage_html)
+
+    @classmethod
+    def _apply_task_lists(cls, storage_html: str) -> str:
+        """Convert GFM-style task list items to Confluence ac:task-list macros.
+
+        md2conf renders GFM task list items (``- [ ]`` / ``- [x]``) as plain
+        ``<ul><li>`` elements with the checkbox marker as literal text.
+        Confluence needs ``<ac:task-list>`` / ``<ac:task>`` elements to render
+        interactive checkboxes.
+
+        Only converts ``<ul>`` blocks whose every ``<li>`` begins with a
+        checkbox marker; mixed lists (some items without a checkbox prefix)
+        are left unchanged.  Nested ``<ul>`` elements are not traversed to
+        avoid partial matches.
+
+        Args:
+            storage_html: Confluence storage-format string to post-process.
+
+        Returns:
+            Updated storage-format string with task lists converted.
+        """
+        task_item_re = re.compile(r"^\[( |x|X)\]\s*(.*)", re.DOTALL)
+
+        def _replace_ul(m: re.Match) -> str:
+            ul_html = m.group(0)
+            items = re.findall(r"<li>(.*?)</li>", ul_html, re.DOTALL)
+            if not items:
+                return ul_html
+
+            task_matches = [task_item_re.match(item) for item in items]
+            if not all(task_matches):
+                return ul_html  # mixed list — leave as-is
+
+            parts = ["<ac:task-list>"]
+            for tm in task_matches:
+                if tm is None:  # should not happen given all(task_matches) above
+                    continue
+                status = "complete" if tm.group(1).lower() == "x" else "incomplete"
+                body = tm.group(2).strip()
+                parts.append(
+                    f"<ac:task>"
+                    f"<ac:task-status>{status}</ac:task-status>"
+                    f"<ac:task-body>{body}</ac:task-body>"
+                    f"</ac:task>"
+                )
+            parts.append("</ac:task-list>")
+            return "".join(parts)
+
+        # Only match <ul> blocks with no nested <ul> to avoid partial tag matches.
+        return re.sub(
+            r"<ul>(?:(?!<ul>).)*?</ul>", _replace_ul, storage_html, flags=re.DOTALL
+        )

--- a/src/mcp_atlassian/servers/confluence.py
+++ b/src/mcp_atlassian/servers/confluence.py
@@ -2694,3 +2694,154 @@ async def copy_page(
         indent=2,
         ensure_ascii=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# Template tools
+# ---------------------------------------------------------------------------
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_templates"},
+    annotations={"title": "List Page Templates", "readOnlyHint": True},
+)
+async def confluence_list_page_templates(
+    ctx: Context,
+    space_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Optional space key to list templates defined in that space. "
+                "When omitted, global templates are returned."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(
+            default=25,
+            ge=1,
+            le=200,
+            description="Maximum number of templates to return.",
+        ),
+    ] = 25,
+) -> str:
+    """List Confluence page content templates.
+
+    Returns template metadata (ID, name, description, type) without the
+    full body.  Use confluence_get_page_template to fetch a template's body.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    try:
+        results = confluence_fetcher.list_page_templates(
+            space_key=space_key,
+            limit=limit,
+        )
+        simplified = [
+            {
+                "templateId": t.get("templateId", ""),
+                "name": t.get("name", ""),
+                "templateType": t.get("templateType", ""),
+                "description": (t.get("description") or {}).get("value", ""),
+            }
+            for t in results
+        ]
+        return json.dumps(
+            {"templates": simplified, "total": len(simplified)},
+            indent=2,
+            ensure_ascii=False,
+        )
+    except MCPAtlassianAuthenticationError as e:
+        logger.error(f"Authentication error listing templates: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Error listing templates: {e}")
+        raise
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "read", "toolset:confluence_templates"},
+    annotations={"title": "Get Page Template", "readOnlyHint": True},
+)
+async def confluence_get_page_template(
+    ctx: Context,
+    template_id: Annotated[
+        str,
+        Field(description="The ID of the template to retrieve."),
+    ],
+) -> str:
+    """Get a Confluence page template by ID, including its storage-format body."""
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    try:
+        template = confluence_fetcher.get_page_template(template_id)
+        body_value = template.get("body", {}).get("storage", {}).get("value", "")
+        return json.dumps(
+            {
+                "templateId": template.get("templateId", ""),
+                "name": template.get("name", ""),
+                "templateType": template.get("templateType", ""),
+                "description": (template.get("description") or {}).get("value", ""),
+                "body": body_value,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    except MCPAtlassianAuthenticationError as e:
+        logger.error(f"Authentication error fetching template {template_id}: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching template {template_id}: {e}")
+        raise
+
+
+@confluence_mcp.tool(
+    tags={"confluence", "write", "toolset:confluence_templates"},
+    annotations={"title": "Create Page from Template", "destructiveHint": False},
+)
+@check_write_access
+async def confluence_create_page_from_template(
+    ctx: Context,
+    space_key: Annotated[
+        str,
+        Field(description="Key of the space in which to create the page."),
+    ],
+    title: Annotated[
+        str,
+        Field(description="Title for the new page."),
+    ],
+    template_id: Annotated[
+        str,
+        Field(description="ID of the template to use as the page body."),
+    ],
+    parent_id: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Optional ID of the parent page.",
+        ),
+    ] = None,
+) -> str:
+    """Create a new Confluence page pre-populated with a template's body.
+
+    Fetches the named template and creates a page with its storage-format
+    content.  The page can be edited afterwards via confluence_update_page.
+    """
+    confluence_fetcher = await get_confluence_fetcher(ctx)
+
+    try:
+        result = confluence_fetcher.create_page_from_template(
+            space_key=space_key,
+            title=title,
+            template_id=template_id,
+            parent_id=parent_id,
+        )
+        return json.dumps(result, indent=2, ensure_ascii=False)
+    except MCPAtlassianAuthenticationError as e:
+        logger.error(f"Authentication error creating page from template: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Error creating page from template {template_id}: {e}")
+        raise

--- a/src/mcp_atlassian/utils/toolsets.py
+++ b/src/mcp_atlassian/utils/toolsets.py
@@ -135,6 +135,11 @@ CONFLUENCE_TOOLSETS: dict[str, ToolsetDefinition] = {
         description="Attachment upload, download, and management",
         default=False,
     ),
+    "confluence_templates": ToolsetDefinition(
+        name="confluence_templates",
+        description="Page template listing and page creation from templates",
+        default=False,
+    ),
 }
 
 # --- Combined registry ---

--- a/tests/unit/confluence/test_templates.py
+++ b/tests/unit/confluence/test_templates.py
@@ -1,0 +1,223 @@
+"""Unit tests for Confluence template operations."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_atlassian.confluence.templates import TemplatesMixin
+
+
+@pytest.fixture
+def templates_mixin(confluence_client):
+    """Return a TemplatesMixin with a mocked Confluence client."""
+    with patch(
+        "mcp_atlassian.confluence.templates.ConfluenceClient.__init__"
+    ) as mock_init:
+        mock_init.return_value = None
+        mixin = TemplatesMixin()
+        mixin.confluence = confluence_client.confluence
+        mixin.config = confluence_client.config
+        mixin.preprocessor = confluence_client.preprocessor
+        return mixin
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_SUMMARY = {
+    "templateId": "tpl-001",
+    "name": "Meeting Notes",
+    "templateType": "page",
+    "description": {"value": "Standard meeting notes template"},
+    "body": {"storage": {"value": "<h1>Meeting Notes</h1>"}},
+}
+
+_TEMPLATE_SUMMARY_2 = {
+    "templateId": "tpl-002",
+    "name": "Project Charter",
+    "templateType": "page",
+    "description": {"value": ""},
+    "body": {"storage": {"value": "<h1>Project Charter</h1>"}},
+}
+
+
+# ---------------------------------------------------------------------------
+# list_page_templates
+# ---------------------------------------------------------------------------
+
+
+class TestListPageTemplates:
+    def test_returns_list_from_api(self, templates_mixin):
+        """list_page_templates returns the raw list from the API."""
+        templates_mixin.confluence.get_content_templates.return_value = [
+            _TEMPLATE_SUMMARY,
+            _TEMPLATE_SUMMARY_2,
+        ]
+
+        result = templates_mixin.list_page_templates()
+
+        templates_mixin.confluence.get_content_templates.assert_called_once_with(
+            space=None,
+            limit=25,
+        )
+        assert len(result) == 2
+        assert result[0]["templateId"] == "tpl-001"
+        assert result[1]["name"] == "Project Charter"
+
+    def test_passes_space_key_and_limit(self, templates_mixin):
+        """list_page_templates forwards space_key and limit to the API."""
+        templates_mixin.confluence.get_content_templates.return_value = []
+
+        templates_mixin.list_page_templates(space_key="ENG", limit=50)
+
+        templates_mixin.confluence.get_content_templates.assert_called_once_with(
+            space="ENG",
+            limit=50,
+        )
+
+    def test_empty_result(self, templates_mixin):
+        """list_page_templates handles an empty result gracefully."""
+        templates_mixin.confluence.get_content_templates.return_value = []
+
+        result = templates_mixin.list_page_templates()
+
+        assert result == []
+
+    def test_api_error_raises(self, templates_mixin):
+        """list_page_templates wraps API errors with a descriptive message."""
+        templates_mixin.confluence.get_content_templates.side_effect = Exception(
+            "network error"
+        )
+
+        with pytest.raises(Exception, match="Failed to list page templates"):
+            templates_mixin.list_page_templates()
+
+
+# ---------------------------------------------------------------------------
+# get_page_template
+# ---------------------------------------------------------------------------
+
+
+class TestGetPageTemplate:
+    def test_returns_template_with_body(self, templates_mixin):
+        """get_page_template returns the full template dict including body."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+
+        result = templates_mixin.get_page_template("tpl-001")
+
+        templates_mixin.confluence.get_content_template.assert_called_once_with(
+            "tpl-001"
+        )
+        assert result["templateId"] == "tpl-001"
+        assert result["body"]["storage"]["value"] == "<h1>Meeting Notes</h1>"
+
+    def test_api_error_raises(self, templates_mixin):
+        """get_page_template wraps API errors with a descriptive message."""
+        templates_mixin.confluence.get_content_template.side_effect = Exception(
+            "not found"
+        )
+
+        with pytest.raises(Exception, match="Failed to get template tpl-999"):
+            templates_mixin.get_page_template("tpl-999")
+
+
+# ---------------------------------------------------------------------------
+# create_page_from_template
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePageFromTemplate:
+    def test_creates_page_with_template_body(self, templates_mixin):
+        """create_page_from_template fetches template then calls create_page."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "999", "title": "My Meeting Notes"}
+        )
+
+        result = templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="My Meeting Notes",
+            template_id="tpl-001",
+        )
+
+        templates_mixin.confluence.get_content_template.assert_called_once_with(
+            "tpl-001"
+        )
+        templates_mixin.confluence.create_page.assert_called_once_with(
+            space="ENG",
+            title="My Meeting Notes",
+            body="<h1>Meeting Notes</h1>",
+            parent_id=None,
+            representation="storage",
+        )
+        assert result["id"] == "999"
+        assert result["space_key"] == "ENG"
+
+    def test_passes_parent_id(self, templates_mixin):
+        """create_page_from_template forwards parent_id to create_page."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "888", "title": "Child Page"}
+        )
+
+        templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="Child Page",
+            template_id="tpl-001",
+            parent_id="777",
+        )
+
+        call_kwargs = templates_mixin.confluence.create_page.call_args[1]
+        assert call_kwargs["parent_id"] == "777"
+
+    def test_url_built_from_config(self, templates_mixin):
+        """create_page_from_template constructs the page URL from config.url."""
+        templates_mixin.confluence.get_content_template.return_value = _TEMPLATE_SUMMARY
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "123", "title": "Test"}
+        )
+
+        result = templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="Test",
+            template_id="tpl-001",
+        )
+
+        assert "123" in result["url"]
+        assert "ENG" in result["url"]
+
+    def test_empty_template_body(self, templates_mixin):
+        """create_page_from_template handles a template with no body gracefully."""
+        templates_mixin.confluence.get_content_template.return_value = {
+            "templateId": "tpl-empty",
+            "name": "Empty",
+            "body": {},
+        }
+        templates_mixin.confluence.create_page = MagicMock(
+            return_value={"id": "500", "title": "Empty Page"}
+        )
+
+        templates_mixin.create_page_from_template(
+            space_key="ENG",
+            title="Empty Page",
+            template_id="tpl-empty",
+        )
+
+        call_kwargs = templates_mixin.confluence.create_page.call_args[1]
+        assert call_kwargs["body"] == ""
+
+    def test_api_error_raises(self, templates_mixin):
+        """create_page_from_template raises when template fetch fails."""
+        templates_mixin.confluence.get_content_template.side_effect = Exception(
+            "not found"
+        )
+
+        with pytest.raises(
+            Exception, match="Failed to create page from template tpl-bad"
+        ):
+            templates_mixin.create_page_from_template(
+                space_key="ENG",
+                title="Whatever",
+                template_id="tpl-bad",
+            )

--- a/tests/unit/preprocessing/test_content_processing.py
+++ b/tests/unit/preprocessing/test_content_processing.py
@@ -927,3 +927,62 @@ Emojis: 😀 😎 🚀 💻 ✅ ❌ ⚡ 🔥"""
             confluence_preprocessor.process_html_content(malformed_content)
         )
         assert len(confluence_result) > 0
+
+
+class TestTaskLists:
+    """Tests for GFM task list → ac:task-list conversion."""
+
+    def _convert(self, md: str, apply_task_lists: bool = True) -> str:
+        p = ConfluencePreprocessor(base_url="https://test.atlassian.net")
+        return p.markdown_to_confluence_storage(md, apply_task_lists=apply_task_lists)
+
+    def test_unchecked_item_becomes_incomplete_task(self):
+        """- [ ] item converts to ac:task with status incomplete."""
+        result = self._convert("- [ ] Todo item")
+        assert "<ac:task-list>" in result
+        assert "<ac:task-status>incomplete</ac:task-status>" in result
+        assert "<ac:task-body>Todo item</ac:task-body>" in result
+
+    def test_checked_item_becomes_complete_task(self):
+        """- [x] item converts to ac:task with status complete."""
+        result = self._convert("- [x] Done item")
+        assert "<ac:task-status>complete</ac:task-status>" in result
+        assert "<ac:task-body>Done item</ac:task-body>" in result
+
+    def test_uppercase_x_treated_as_complete(self):
+        """- [X] (uppercase) is also treated as complete."""
+        result = self._convert("- [X] Done")
+        assert "<ac:task-status>complete</ac:task-status>" in result
+
+    def test_mixed_list_left_as_ul(self):
+        """A list mixing task and non-task items is left as a plain <ul>."""
+        result = self._convert("- [ ] Task\n- Regular item")
+        assert "<ul>" in result
+        assert "<ac:task-list>" not in result
+
+    def test_multiple_tasks_in_one_list(self):
+        """All tasks in a list are converted, preserving order."""
+        result = self._convert("- [ ] First\n- [x] Second\n- [ ] Third")
+        assert result.count("<ac:task>") == 3
+        assert result.index("First") < result.index("Second") < result.index("Third")
+
+    def test_apply_task_lists_false_leaves_ul(self):
+        """apply_task_lists=False skips conversion entirely."""
+        result = self._convert("- [ ] Skip me", apply_task_lists=False)
+        assert "<ul>" in result
+        assert "<ac:task-list>" not in result
+
+    def test_apply_task_lists_classmethod_directly(self):
+        """_apply_task_lists can be called as a classmethod."""
+        html = "<ul><li>[ ] Todo</li><li>[x] Done</li></ul>"
+        result = ConfluencePreprocessor._apply_task_lists(html)
+        assert "<ac:task-list>" in result
+        assert "<ac:task-status>incomplete</ac:task-status>" in result
+        assert "<ac:task-status>complete</ac:task-status>" in result
+        assert "<ul>" not in result
+
+    def test_non_task_ul_not_modified(self):
+        """A plain <ul> with no checkbox markers is left untouched."""
+        html = "<ul><li>Alpha</li><li>Beta</li></ul>"
+        result = ConfluencePreprocessor._apply_task_lists(html)
+        assert result == html

--- a/tests/unit/utils/test_toolsets.py
+++ b/tests/unit/utils/test_toolsets.py
@@ -34,12 +34,12 @@ class TestGetEnabledToolsets:
         assert result == expected
 
     def test_all_keyword(self, monkeypatch):
-        """Test 'all' keyword returns all 21 toolset names."""
+        """Test 'all' keyword returns all 22 toolset names."""
         monkeypatch.setenv("TOOLSETS", "all")
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_all_keyword_case_insensitive(self, monkeypatch):
         """Test 'ALL' keyword is case-insensitive."""
@@ -47,7 +47,7 @@ class TestGetEnabledToolsets:
         result = get_enabled_toolsets()
         assert result is not None
         assert result == set(ALL_TOOLSETS.keys())
-        assert len(result) == 21
+        assert len(result) == 22
 
     def test_default_keyword(self, monkeypatch):
         """Test 'default' keyword returns 6 default toolset names."""
@@ -91,15 +91,15 @@ class TestGetEnabledToolsets:
         assert DEFAULT_TOOLSETS == expected_defaults
 
     def test_all_toolsets_count(self):
-        """Verify ALL_TOOLSETS has exactly 21 entries."""
-        assert len(ALL_TOOLSETS) == 21
+        """Verify ALL_TOOLSETS has exactly 22 entries."""
+        assert len(ALL_TOOLSETS) == 22
 
     def test_all_toolsets_contains_jira_and_confluence(self):
         """Verify ALL_TOOLSETS has both Jira and Confluence toolsets."""
         jira_toolsets = {k for k in ALL_TOOLSETS if k.startswith("jira_")}
         confluence_toolsets = {k for k in ALL_TOOLSETS if k.startswith("confluence_")}
         assert len(jira_toolsets) == 15
-        assert len(confluence_toolsets) == 6
+        assert len(confluence_toolsets) == 7
 
 
 class TestShouldIncludeToolByToolset:
@@ -253,6 +253,6 @@ class TestToolsetTagCompleteness:
 
     def test_confluence_tool_count(self, confluence_tools):
         """Verify expected number of Confluence tools."""
-        assert len(confluence_tools) == 32, (
-            f"Expected 32 Confluence tools, got {len(confluence_tools)}"
+        assert len(confluence_tools) == 35, (
+            f"Expected 35 Confluence tools, got {len(confluence_tools)}"
         )


### PR DESCRIPTION
## Summary

Integrates upstream PR [sooperset/mcp-atlassian#1180](https://github.com/sooperset/mcp-atlassian/pull/1180) as-is with conflict resolution.

- **GFM task lists:** `_apply_task_lists` post-processor converts `- [ ]`/`- [x]` items to Confluence `ac:task-list` macros. On by default. Only converts `<ul>` blocks where every `<li>` has a checkbox marker — no false positives.
- **Template tools:** New `TemplatesMixin` + 3 tools (`list_page_templates`, `get_page_template`, `create_page_from_template`) in opt-in `confluence_templates` toolset (non-default)
- **+3 tools** (templates), **+1 toolset** (`confluence_templates`)

## Test plan

- [x] 20 new tests (8 task list, 12 templates)
- [x] Full suite: 2877 passed, 0 failures, 0 warnings (`-W error`)
- [x] Pre-commit clean (ruff, ruff-format, mypy)
- [x] Security review: library methods only, pure regex for task lists, `@handle_auth_errors` + `@check_write_access` applied

Closes #173

Closes #273