### PR TITLE
fix(confluence): make add_inline_comment Cloud-only and propagate ValueError (closes #274)

### DIFF
--- a/src/mcp_atlassian/confluence/comments.py
+++ b/src/mcp_atlassian/confluence/comments.py
@@ -319,8 +319,10 @@ class CommentsMixin(ConfluenceClient):
     ) -> ConfluenceComment | None:
         """Add an inline comment anchored to a text selection on a page.
 
-        For Cloud instances, uses the v2 API (POST /api/v2/inline-comments).
-        For Server/DC, uses the v1 API (POST /rest/api/content/).
+        Inline comments are Cloud-only.  The v2 API
+        (``POST /wiki/api/v2/inline-comments``) is the only supported path;
+        the v1 endpoint returns 405 on Cloud and is not available on
+        Server/DC.
 
         Args:
             page_id: The ID of the page to add the inline comment to
@@ -333,57 +335,47 @@ class CommentsMixin(ConfluenceClient):
 
         Returns:
             ConfluenceComment object if successful, None otherwise
+
+        Raises:
+            ValueError: If the Confluence instance is not Cloud, or if the
+                API returns an actionable error (e.g. text not found).
         """
+        if not self.config.is_cloud:
+            raise ValueError(
+                "Inline comments are only supported on Confluence Cloud. "
+                "The v2 inline-comments API is not available on Server/DC."
+            )
+
         try:
             # Convert markdown to Confluence storage format if needed
             if not content.strip().startswith("<"):
                 content = self.preprocessor.markdown_to_confluence_storage(content)
 
             v2_adapter = self._inline_v2_adapter
-            if v2_adapter:
-                response = v2_adapter.create_inline_comment(
-                    page_id=page_id,
-                    body=content,
-                    text_selection=text_selection,
-                    text_selection_match_count=text_selection_match_count,
-                    text_selection_match_index=text_selection_match_index,
-                )
-                space_key = ""
-            else:
-                # v1 API: POST /rest/api/content/ with inline location
-                data: dict[str, Any] = {
-                    "type": "comment",
-                    "container": {
-                        "id": page_id,
-                        "type": "page",
-                    },
-                    "body": {
-                        "storage": {
-                            "value": content,
-                            "representation": "storage",
-                        },
-                    },
-                    "extensions": {
-                        "location": "inline",
-                        "inlineProperties": {
-                            "originalSelection": text_selection,
-                        },
-                    },
-                }
-                page = self.confluence.get_page_by_id(page_id=page_id, expand="space")
-                space_key = page.get("space", {}).get("key", "")
-                response = self.confluence.post("rest/api/content/", data=data)
+            if not v2_adapter:
+                logger.error("Failed to create v2 adapter for inline comments")
+                return None
+
+            response = v2_adapter.create_inline_comment(
+                page_id=page_id,
+                body=content,
+                text_selection=text_selection,
+                text_selection_match_count=text_selection_match_count,
+                text_selection_match_index=text_selection_match_index,
+            )
 
             if not response:
                 logger.error("Failed to add inline comment: empty response")
                 return None
 
-            return self._process_comment_response(response, space_key)
+            return self._process_comment_response(response, space_key="")
 
+        except ValueError:
+            raise
         except requests.RequestException as e:
             logger.error(f"Network error when adding inline comment: {str(e)}")
             return None
-        except (ValueError, TypeError, KeyError) as e:
+        except (TypeError, KeyError) as e:
             logger.error(f"Error processing inline comment data: {str(e)}")
             return None
         except Exception as e:  # noqa: BLE001 - Intentional fallback with full logging

--- a/tests/unit/confluence/test_comments.py
+++ b/tests/unit/confluence/test_comments.py
@@ -1,6 +1,6 @@
 """Unit tests for the CommentsMixin class."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 import requests
@@ -669,34 +669,12 @@ class TestGetInlineComments:
 class TestAddInlineComment:
     """Tests for add_inline_comment method."""
 
-    def test_add_inline_comment_v1_success(self, comments_mixin_dc):
-        """add_inline_comment v1 (Server/DC) posts with inline location."""
-        page_id = "12345"
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
-        }
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
-            "<p>Inline comment</p>"
-        )
-        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
-        comments_mixin_dc.preprocessor.process_html_content.return_value = (
-            "<p>Inline comment</p>",
-            "Inline comment",
-        )
-
-        result = comments_mixin_dc.add_inline_comment(
-            page_id, "Inline comment", "some text to anchor"
-        )
-
-        assert result is not None
-        assert result.location == "inline"
-        call_args = comments_mixin_dc.confluence.post.call_args
-        assert call_args[0][0] == "rest/api/content/"
-        data = call_args[1]["data"]
-        assert data["extensions"]["location"] == "inline"
-        assert data["extensions"]["inlineProperties"]["originalSelection"] == (
-            "some text to anchor"
-        )
+    def test_add_inline_comment_raises_for_server_dc(self, comments_mixin_dc):
+        """add_inline_comment raises ValueError on Server/DC (Cloud-only API)."""
+        with pytest.raises(ValueError, match="only supported on Confluence Cloud"):
+            comments_mixin_dc.add_inline_comment(
+                "12345", "Inline comment", "some text to anchor"
+            )
 
     def test_add_inline_comment_v2_cloud_success(self, comments_mixin):
         """add_inline_comment uses v2 API on Cloud (any auth type)."""
@@ -750,52 +728,76 @@ class TestAddInlineComment:
         # v1 API should not be called
         comments_mixin.confluence.post.assert_not_called()
 
-    def test_add_inline_comment_with_html_content(self, comments_mixin_dc):
-        """add_inline_comment skips markdown conversion for HTML content (Server/DC)."""
+    def test_add_inline_comment_with_html_content(self, comments_mixin):
+        """add_inline_comment skips markdown conversion for HTML content."""
         html_content = "<p>Already <strong>HTML</strong></p>"
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
+
+        v2_converted = {
+            "id": "444555666",
+            "type": "comment",
+            "status": "open",
+            "body": {"view": {"value": html_content, "representation": "view"}},
+            "extensions": {"location": "inline"},
+            "version": {"number": 1},
+            "_links": {},
         }
-        comments_mixin_dc.confluence.post.return_value = MOCK_INLINE_COMMENT_V1_RESPONSE
-        comments_mixin_dc.preprocessor.process_html_content.return_value = (
+        comments_mixin.preprocessor.process_html_content.return_value = (
             html_content,
-            "Already **HTML**",
+            "Already HTML",
         )
 
-        result = comments_mixin_dc.add_inline_comment(
-            "12345", html_content, "some text"
-        )
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.return_value = v2_converted
 
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.assert_not_called()
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=PropertyMock,
+            return_value=mock_adapter,
+        ):
+            result = comments_mixin.add_inline_comment(
+                "12345", html_content, "some text"
+            )
+
+        comments_mixin.preprocessor.markdown_to_confluence_storage.assert_not_called()
         assert result is not None
 
-    def test_add_inline_comment_empty_response(self, comments_mixin_dc):
-        """add_inline_comment returns None on empty API response (Server/DC)."""
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
-        }
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+    def test_add_inline_comment_propagates_value_error(self, comments_mixin):
+        """add_inline_comment propagates ValueError (e.g. text not found)."""
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
             "<p>Test</p>"
         )
-        comments_mixin_dc.confluence.post.return_value = None
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.side_effect = ValueError(
+            "text not found on page"
+        )
 
-        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=PropertyMock,
+            return_value=mock_adapter,
+        ):
+            with pytest.raises(ValueError, match="text not found on page"):
+                comments_mixin.add_inline_comment("12345", "Test", "missing text")
 
-        assert result is None
-
-    def test_add_inline_comment_network_error(self, comments_mixin_dc):
-        """add_inline_comment returns None on network error (Server/DC)."""
-        comments_mixin_dc.confluence.get_page_by_id.return_value = {
-            "space": {"key": "TEST"}
-        }
-        comments_mixin_dc.preprocessor.markdown_to_confluence_storage.return_value = (
+    def test_add_inline_comment_network_error(self, comments_mixin):
+        """add_inline_comment returns None on network error."""
+        comments_mixin.preprocessor.markdown_to_confluence_storage.return_value = (
             "<p>Test</p>"
         )
-        comments_mixin_dc.confluence.post.side_effect = requests.RequestException(
+        mock_adapter = MagicMock()
+        mock_adapter.create_inline_comment.side_effect = requests.RequestException(
             "Network error"
         )
 
-        result = comments_mixin_dc.add_inline_comment("12345", "Test", "anchor text")
+        with patch.object(
+            type(comments_mixin),
+            "_inline_v2_adapter",
+            new_callable=PropertyMock,
+            return_value=mock_adapter,
+        ):
+            result = comments_mixin.add_inline_comment("12345", "Test", "anchor text")
 
         assert result is None
 


### PR DESCRIPTION
## Summary

Cherry-picks two design improvements from upstream PR [sooperset/mcp-atlassian#1182](https://github.com/sooperset/mcp-atlassian/pull/1182) (kbichave) into our existing inline comment implementation (from #1151):

- **Cloud-only guard:** `add_inline_comment` now raises `ValueError` for Server/DC instances. The v1 inline endpoint doesn't work — the v2 API is Cloud-only. Previously we had a dead v1 code path that would silently fail.
- **ValueError propagation:** API-level `ValueError` (e.g. "text not found on page") now propagates to callers instead of being swallowed to `None`.

We already had the full inline comment feature from PR #1151 (SmallChX). This PR improves it with kbichave's better error handling design rather than replacing it wholesale.

## Test plan

- [x] `test_add_inline_comment_raises_for_server_dc` — new test for Cloud-only guard
- [x] `test_add_inline_comment_propagates_value_error` — new test for ValueError propagation
- [x] Updated existing tests from Server/DC fixtures to Cloud fixtures
- [x] Full suite: 2877 passed, 0 failures, 0 warnings (`-W error`)
- [x] Pre-commit clean

Closes #274