### PR TITLE
fix(jira): get field options for cascading select fields (closes #275)

### DIFF
--- a/src/mcp_atlassian/jira/field_options.py
+++ b/src/mcp_atlassian/jira/field_options.py
@@ -109,8 +109,8 @@ class FieldOptionsMixin(JiraClient):
             global_ctx = next((c for c in contexts if c.is_global_context), None)
             context_id = global_ctx.id if global_ctx else contexts[0].id
 
-        # Paginate through all options
-        all_options: list[FieldOption] = []
+        # Paginate through all option entries (Cloud returns a flat list).
+        raw_items: list[dict] = []
         start_at = 0
         max_results = 100
 
@@ -127,7 +127,7 @@ class FieldOptionsMixin(JiraClient):
                 values = response.get("values", [])
                 for item in values:
                     if isinstance(item, dict):
-                        all_options.append(FieldOption.from_api_response(item))
+                        raw_items.append(item)
 
                 total = response.get("total", len(values))
                 start_at += len(values)
@@ -141,7 +141,70 @@ class FieldOptionsMixin(JiraClient):
                 )
                 break
 
-        return all_options
+        # Build parent -> children mapping. Cloud main endpoint returns a
+        # flat list where child items include an "optionId" referencing
+        # their parent's id. Prefer calling the cascade-specific endpoint
+        # per parent (with pagination) to get authoritative child objects;
+        # fall back to grouping by optionId only when that endpoint is
+        # unreachable (exception), so an explicitly empty cascade response
+        # is trusted and does not trigger the fallback.
+        items_by_id = {str(item.get("id", "")): item for item in raw_items}
+        parent_ids = [iid for iid, it in items_by_id.items() if not it.get("optionId")]
+
+        result: list[FieldOption] = []
+
+        for pid in parent_ids:
+            parent_item = items_by_id.get(pid, {})
+            child_items: list[dict] = []
+            # True once the cascade endpoint responds (even with empty results),
+            # so an empty authoritative response is not confused with a failure.
+            cascade_fetched = False
+            cascade_start = 0
+            cascade_max = 100
+
+            while True:
+                try:
+                    cascade_resp = self.jira.get(
+                        f"rest/api/3/field/{field_id}/context/{context_id}"
+                        f"/option/{pid}/cascadingOption",
+                        params={"startAt": cascade_start, "maxResults": cascade_max},
+                    )
+                    cascade_fetched = True
+
+                    if isinstance(cascade_resp, dict):
+                        page = cascade_resp.get("values")
+                        page_items: list[dict] = (
+                            [c for c in page if isinstance(c, dict)]
+                            if page is not None
+                            else []
+                        )
+                        child_items.extend(page_items)
+                        total = cascade_resp.get("total", len(page_items))
+                        cascade_start += len(page_items)
+                        if cascade_start >= total or not page_items:
+                            break
+                    else:
+                        break
+
+                except Exception as e:
+                    logger.debug(
+                        f"Cascade endpoint unavailable for field {field_id} "
+                        f"option {pid}: {e}. Falling back to flat-list grouping."
+                    )
+                    break
+
+            # Fallback: reconstruct hierarchy from flat-list "optionId" references,
+            # but only when the cascade endpoint was not reachable.
+            if not cascade_fetched:
+                child_items = [it for it in raw_items if it.get("optionId") == pid]
+
+            children = [FieldOption.from_api_response(c) for c in child_items]
+            parent_opt = FieldOption.from_api_response(parent_item).model_copy(
+                update={"child_options": children}
+            )
+            result.append(parent_opt)
+
+        return result
 
     def _get_field_options_server(
         self,

--- a/src/mcp_atlassian/models/jira/field_option.py
+++ b/src/mcp_atlassian/models/jira/field_option.py
@@ -23,7 +23,9 @@ class FieldContext(ApiModel):
     is_any_issue_type: bool = False
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldContext":
+    def from_api_response(
+        cls, data: dict[str, Any] | str | None, **kwargs: Any
+    ) -> "FieldContext":
         """Create a FieldContext from a Jira API response.
 
         Args:
@@ -65,7 +67,9 @@ class FieldOption(ApiModel):
     child_options: list["FieldOption"] = Field(default_factory=list)
 
     @classmethod
-    def from_api_response(cls, data: dict[str, Any], **kwargs: Any) -> "FieldOption":
+    def from_api_response(
+        cls, data: dict[str, Any] | str | None, **kwargs: Any
+    ) -> "FieldOption":
         """Create a FieldOption from a Jira API response.
 
         Args:
@@ -74,14 +78,29 @@ class FieldOption(ApiModel):
         Returns:
             A FieldOption instance
         """
+        # Handle simple string values (some API shapes use strings for
+        # allowedValues/children). If `data` is a bare string, treat it
+        # as a value-only FieldOption.
+        if isinstance(data, str):
+            return cls(id="", value=data)
+
         if not data or not isinstance(data, dict):
             return cls(id="", value="")
 
-        children = [
-            cls.from_api_response(c)
-            for c in data.get("cascadingOptions", [])
-            if isinstance(c, dict)
-        ]
+        # Server/DC createmeta uses "children"; Cloud/legacy uses
+        # "cascadingOptions". Use key presence so an explicit empty list
+        # is never mistaken for a missing key.
+        if "cascadingOptions" in data:
+            raw_children: list[Any] = data["cascadingOptions"]
+        elif "children" in data:
+            raw_children = data["children"]
+        else:
+            raw_children = []
+
+        children: list[FieldOption] = []
+        for c in raw_children:
+            if isinstance(c, dict):
+                children.append(cls.from_api_response(c))
 
         return cls(
             id=str(data.get("id", data.get("optionId", ""))),

--- a/tests/unit/jira/test_field_options.py
+++ b/tests/unit/jira/test_field_options.py
@@ -155,6 +155,45 @@ class TestFieldOptionModel:
         assert opt.child_options[0].value == "United States"
         assert opt.child_options[1].value == "Canada"
 
+    def test_children_key_server_dc(self):
+        """Server/DC createmeta uses 'children' instead of 'cascadingOptions'."""
+        data = {
+            "id": "10200",
+            "value": "North America",
+            "children": [
+                {"id": "10201", "value": "United States"},
+                {"id": "10202", "value": "Canada"},
+            ],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.value == "North America"
+        assert len(opt.child_options) == 2
+        assert opt.child_options[0].value == "United States"
+        assert opt.child_options[1].value == "Canada"
+
+    def test_cascading_options_empty_list_not_shadowed_by_children(self):
+        """An explicit empty cascadingOptions is not overridden by children."""
+        data = {
+            "id": "10200",
+            "value": "Parent",
+            "cascadingOptions": [],
+            "children": [{"id": "1", "value": "Should not appear"}],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert opt.child_options == []
+
+    def test_cascading_options_key_takes_precedence_over_children(self):
+        """cascadingOptions wins when both keys are present."""
+        data = {
+            "id": "10200",
+            "value": "Parent",
+            "cascadingOptions": [{"id": "1", "value": "Cascade Child"}],
+            "children": [{"id": "2", "value": "Regular Child"}],
+        }
+        opt = FieldOption.from_api_response(data)
+        assert len(opt.child_options) == 1
+        assert opt.child_options[0].value == "Cascade Child"
+
     def test_to_simplified_dict_with_children(self):
         opt = FieldOption(
             id="1",
@@ -339,28 +378,125 @@ class TestFieldOptionsMixin:
 
     def test_options_cloud_cascading(self, mixin):
         mixin.config.is_cloud = True
+        # Cloud main endpoint returns a flat list; children reference
+        # their parent via "optionId" or are available via the
+        # cascade-specific endpoint. Mock the main list followed by
+        # the cascade endpoint response for the parent.
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [
-                    {
-                        "id": "10200",
-                        "value": "Americas",
-                        "cascadingOptions": [
-                            {"id": "10201", "value": "US"},
-                            {"id": "10202", "value": "Canada"},
-                        ],
-                    }
-                ],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 1,
-            }
+            side_effect=[
+                # main options list (parent only)
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade-specific endpoint for parent 10200
+                {
+                    "values": [
+                        {"id": "10201", "value": "US"},
+                        {"id": "10202", "value": "Canada"},
+                    ]
+                },
+            ]
         )
 
         result = mixin.get_field_options("customfield_10020", context_id="10001")
         assert len(result) == 1
         assert result[0].value == "Americas"
         assert len(result[0].child_options) == 2
+
+    def test_options_cloud_cascading_cascade_pagination(self, mixin):
+        """Cascade endpoint paginates across multiple pages."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options list (one parent)
+                {
+                    "values": [{"id": "10200", "value": "Americas"}],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade endpoint page 1
+                {
+                    "values": [
+                        {"id": "10201", "value": "US"},
+                        {"id": "10202", "value": "Canada"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+                # cascade endpoint page 2
+                {
+                    "values": [{"id": "10203", "value": "Mexico"}],
+                    "startAt": 2,
+                    "maxResults": 2,
+                    "total": 3,
+                },
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 3
+        assert result[0].child_options[2].value == "Mexico"
+
+    def test_options_cloud_cascading_flat_list_fallback(self, mixin):
+        """When cascade endpoint is unreachable, fall back to optionId grouping."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options: parent + children as flat list with optionId
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                        {"id": "10201", "value": "US", "optionId": "10200"},
+                        {"id": "10202", "value": "Canada", "optionId": "10200"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 3,
+                },
+                # cascade endpoint unavailable
+                Exception("404 Not Found"),
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 2
+        assert {c.value for c in result[0].child_options} == {"US", "Canada"}
+
+    def test_options_cloud_cascading_empty_cascade_no_fallback(self, mixin):
+        """Empty cascade response is trusted; optionId fallback must not trigger."""
+        mixin.config.is_cloud = True
+        mixin.jira.get = MagicMock(
+            side_effect=[
+                # main options: parent + flat-list child (optionId present)
+                {
+                    "values": [
+                        {"id": "10200", "value": "Americas"},
+                        {"id": "10201", "value": "US", "optionId": "10200"},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 2,
+                },
+                # cascade endpoint responds but says no children
+                {"values": [], "total": 0},
+            ]
+        )
+
+        result = mixin.get_field_options("customfield_10020", context_id="10001")
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert result[0].child_options == []
 
     # -- get_field_options (Server/DC) --------------------------------------
 
@@ -517,6 +653,47 @@ class TestFieldOptionsMixin:
         assert len(result) == 1
         assert result[0].value == "Yes"
 
+    def test_options_server_cascading_children_key(self, mixin):
+        """Server/DC allowedValues with 'children' key for cascading select."""
+        mixin.config.is_cloud = False
+        mixin.get_project_issue_types = MagicMock(
+            return_value=[{"id": "10001", "name": "Bug"}]
+        )
+        mixin.jira.issue_createmeta_fieldtypes = MagicMock(
+            return_value={
+                "maxResults": 50,
+                "startAt": 0,
+                "total": 1,
+                "isLast": True,
+                "values": [
+                    {
+                        "fieldId": "customfield_10020",
+                        "required": False,
+                        "name": "Region",
+                        "allowedValues": [
+                            {
+                                "id": "10200",
+                                "value": "Americas",
+                                "children": [
+                                    {"id": "10201", "value": "US"},
+                                    {"id": "10202", "value": "Canada"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        result = mixin.get_field_options(
+            "customfield_10020", project_key="TEST", issue_type="Bug"
+        )
+        assert len(result) == 1
+        assert result[0].value == "Americas"
+        assert len(result[0].child_options) == 2
+        assert result[0].child_options[0].value == "US"
+        assert result[0].child_options[1].value == "Canada"
+
 
 # ============================================================================
 # Regression Tests — upstream #673
@@ -549,16 +726,23 @@ class TestGetFieldOptionsRegression673:
         (strings) for a custom field so callers know what to submit.
         """
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [
-                    {"id": "10100", "value": "Blocker", "disabled": False},
-                    {"id": "10101", "value": "Critical", "disabled": False},
-                    {"id": "10102", "value": "Major", "disabled": False},
-                ],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 3,
-            }
+            side_effect=[
+                # main options list (flat, no children)
+                {
+                    "values": [
+                        {"id": "10100", "value": "Blocker", "disabled": False},
+                        {"id": "10101", "value": "Critical", "disabled": False},
+                        {"id": "10102", "value": "Major", "disabled": False},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 3,
+                },
+                # cascade endpoint for each parent (empty — no children)
+                {"values": []},
+                {"values": []},
+                {"values": []},
+            ]
         )
 
         result = mixin.get_field_options("customfield_10016", context_id="10001")
@@ -573,12 +757,16 @@ class TestGetFieldOptionsRegression673:
     def test_get_field_options_returns_field_option_objects(self, mixin):
         """Each returned item is a FieldOption with id, value, disabled attrs."""
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [{"id": "10200", "value": "Yes", "disabled": False}],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 1,
-            }
+            side_effect=[
+                {
+                    "values": [{"id": "10200", "value": "Yes", "disabled": False}],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 1,
+                },
+                # cascade endpoint (empty)
+                {"values": []},
+            ]
         )
 
         result = mixin.get_field_options("customfield_10020", context_id="10001")
@@ -593,15 +781,20 @@ class TestGetFieldOptionsRegression673:
     def test_get_field_options_to_simplified_dict_contract(self, mixin):
         """to_simplified_dict() provides the serialisable form consumers need."""
         mixin.jira.get = MagicMock(
-            return_value={
-                "values": [
-                    {"id": "10300", "value": "Done", "disabled": False},
-                    {"id": "10301", "value": "Won't Do", "disabled": True},
-                ],
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 2,
-            }
+            side_effect=[
+                {
+                    "values": [
+                        {"id": "10300", "value": "Done", "disabled": False},
+                        {"id": "10301", "value": "Won't Do", "disabled": True},
+                    ],
+                    "startAt": 0,
+                    "maxResults": 50,
+                    "total": 2,
+                },
+                # cascade endpoint for each parent (empty)
+                {"values": []},
+                {"values": []},
+            ]
         )
 
         result = mixin.get_field_options("customfield_10030", context_id="10001")


### PR DESCRIPTION
## Summary

Integrates upstream PR [sooperset/mcp-atlassian#1187](https://github.com/sooperset/mcp-atlassian/pull/1187) (ffsetit) with conflict resolution.

- **Cloud:** Fetches cascading children via dedicated cascade endpoint with pagination, falls back to `optionId` grouping when endpoint unavailable
- **Model:** `FieldOption.from_api_response` accepts both `cascadingOptions` and `children` keys, plus bare string values
- **Server/DC:** Recognizes `children` key from createmeta

### Roadmap alignment

- **Phase A:** N/A — fixes existing tool output, no param changes
- **Phase B:** N/A — no new discovery tools
- **Phase C:** N/A — no new standalone tools

## Test plan

- [x] 7 new tests (model: children key, key precedence, empty list; cloud: cascade pagination, flat-list fallback, server cascading)
- [x] Updated our #673 regression tests for new cascade-aware Cloud flow
- [x] Full suite: 2888 passed, 0 failures, 0 warnings (`-W error`)
- [x] Pre-commit clean
- [x] Security review: uses existing `self.jira.get()`, no new auth patterns

Closes #275