### PR TITLE
fix(jira): simplify remote issue links shape for LLM consumption (closes #287)

### DIFF
--- a/src/mcp_atlassian/jira/links.py
+++ b/src/mcp_atlassian/jira/links.py
@@ -188,26 +188,64 @@ class LinksMixin(JiraClient):
     def get_remote_issue_links(self, issue_key: str) -> list[dict[str, Any]]:
         """Get remote links (web links, Confluence links) for an issue.
 
+        Returns a simplified list of remote link dicts with fields useful
+        for LLM consumption: ``id``, ``url``, ``title``, and optionally
+        ``summary``, ``relationship``, ``application``, and ``resolved``.
+
         Args:
             issue_key: The issue key (e.g., 'PROJ-123')
 
         Returns:
-            List of remote link data dictionaries
+            List of simplified remote link dicts
 
         Raises:
+            ValueError: If issue_key is empty
             MCPAtlassianAuthenticationError: If authentication fails
         """
+        if not issue_key:
+            raise ValueError("Issue key is required")
+
         try:
             if self.config.is_cloud:
                 endpoint = f"rest/api/3/issue/{issue_key}/remotelink"
             else:
                 endpoint = f"rest/api/2/issue/{issue_key}/remotelink"
-            result = self.jira.get(endpoint)
-            if isinstance(result, list):
-                return result
-            if isinstance(result, dict):
-                return result.get("remoteLinks", [result])
-            return []
+            response = self.jira.get(endpoint)
+
+            # Normalise response to a list of raw link dicts
+            if isinstance(response, list):
+                raw_links = response
+            elif isinstance(response, dict):
+                raw_links = response.get("remoteLinks", [response])
+            else:
+                logger.error(
+                    "Unexpected response type from remote links API: %s",
+                    type(response),
+                )
+                return []
+
+            # Extract LLM-relevant fields, drop API noise
+            results: list[dict[str, Any]] = []
+            for link in raw_links:
+                obj = link.get("object", {})
+                result: dict[str, Any] = {
+                    "id": link.get("id"),
+                    "url": obj.get("url", ""),
+                    "title": obj.get("title", ""),
+                }
+                if obj.get("summary"):
+                    result["summary"] = obj["summary"]
+                if link.get("relationship"):
+                    result["relationship"] = link["relationship"]
+                application = link.get("application", {})
+                if application.get("name"):
+                    result["application"] = application["name"]
+                status = obj.get("status", {})
+                if status.get("resolved") is not None:
+                    result["resolved"] = status["resolved"]
+                results.append(result)
+
+            return results
         except HTTPError:
             raise  # let decorator handle auth errors
         except Exception as e:

--- a/tests/unit/jira/test_links.py
+++ b/tests/unit/jira/test_links.py
@@ -219,37 +219,64 @@ class TestLinksMixin:
         url: str,
         api_version: str,
     ):
-        """Test successful retrieval of remote issue links."""
+        """Test successful retrieval with simplified shape extraction."""
         config = jira_config_factory(url=url)
         mixin = LinksMixin(config=config)
         mixin.jira = mock_atlassian_jira
-        mock_links = [
+        mock_response = [
             {
-                "id": 1,
+                "id": 10000,
+                "self": "https://jira.example.com/rest/api/3/...",
+                "globalId": "system=https://github.com&id=42",
                 "object": {
-                    "url": "https://example.com",
-                    "title": "Link 1",
+                    "url": "https://github.com/org/repo/pull/42",
+                    "title": "PR #42: Fix bug",
+                    "summary": "A pull request",
+                    "icon": {"url16x16": "https://github.com/favicon.ico"},
+                    "status": {"resolved": False},
                 },
+                "relationship": "links to",
+                "application": {"type": "com.github", "name": "GitHub"},
             },
             {
-                "id": 2,
+                "id": 10001,
                 "object": {
-                    "url": "https://example.org",
-                    "title": "Link 2",
+                    "url": "https://example.com/docs",
+                    "title": "Documentation",
                 },
             },
         ]
-        mixin.jira.get.return_value = mock_links
+        mixin.jira.get.return_value = mock_response
 
         result = mixin.get_remote_issue_links("PROJ-123")
 
-        assert result == mock_links
+        assert len(result) == 2
+        # First link: all optional fields present
+        assert result[0]["id"] == 10000
+        assert result[0]["url"] == "https://github.com/org/repo/pull/42"
+        assert result[0]["title"] == "PR #42: Fix bug"
+        assert result[0]["summary"] == "A pull request"
+        assert result[0]["relationship"] == "links to"
+        assert result[0]["application"] == "GitHub"
+        assert result[0]["resolved"] is False
+        # Noise fields excluded
+        assert "self" not in result[0]
+        assert "globalId" not in result[0]
+        assert "icon" not in result[0]
+        # Second link: minimal fields only
+        assert result[1]["id"] == 10001
+        assert result[1]["url"] == "https://example.com/docs"
+        assert result[1]["title"] == "Documentation"
+        assert "summary" not in result[1]
+        assert "relationship" not in result[1]
+        assert "application" not in result[1]
+        assert "resolved" not in result[1]
         mixin.jira.get.assert_called_once_with(
             f"rest/api/{api_version}/issue/PROJ-123/remotelink"
         )
 
     def test_get_remote_issue_links_dict_response(self, links_mixin):
-        """Test dict responses are unwrapped correctly."""
+        """Test dict responses are unwrapped and simplified."""
         inner = [
             {
                 "id": 1,
@@ -263,10 +290,12 @@ class TestLinksMixin:
 
         result = links_mixin.get_remote_issue_links("PROJ-123")
 
-        assert result == inner
+        assert len(result) == 1
+        assert result[0]["url"] == "https://example.com"
+        assert result[0]["title"] == "A"
 
     def test_get_remote_issue_links_dict_without_key(self, links_mixin):
-        """Dict without remoteLinks wraps as single-element list."""
+        """Dict without remoteLinks wraps as single-element list and simplifies."""
         single = {
             "id": 1,
             "object": {
@@ -278,11 +307,25 @@ class TestLinksMixin:
 
         result = links_mixin.get_remote_issue_links("PROJ-123")
 
-        assert result == [single]
+        assert len(result) == 1
+        assert result[0]["url"] == "https://example.com"
 
     def test_get_remote_issue_links_empty(self, links_mixin):
         """Test empty list response."""
         links_mixin.jira.get.return_value = []
+
+        result = links_mixin.get_remote_issue_links("PROJ-123")
+
+        assert result == []
+
+    def test_get_remote_issue_links_missing_issue_key(self, links_mixin):
+        """Test empty issue key raises ValueError."""
+        with pytest.raises(ValueError, match="Issue key is required"):
+            links_mixin.get_remote_issue_links("")
+
+    def test_get_remote_issue_links_unexpected_response(self, links_mixin):
+        """Test non-list/non-dict response returns empty list."""
+        links_mixin.jira.get.return_value = "not a list"
 
         result = links_mixin.get_remote_issue_links("PROJ-123")
 


### PR DESCRIPTION
## Summary

Cherry-picks improvements from upstream PR [sooperset/mcp-atlassian#1190](https://github.com/sooperset/mcp-atlassian/pull/1190) (qinqon) into our existing `get_remote_issue_links` implementation:

- **Simplified shape:** Extracts LLM-relevant fields (`id`, `url`, `title`, `summary`, `relationship`, `application`, `resolved`) and drops API noise (`self`, `globalId`, `icon` objects)
- **Input validation:** `ValueError` for empty `issue_key`
- **Unexpected response handling:** Returns `[]` for non-list/non-dict responses

Does NOT add a standalone `jira_get_remote_issue_links` tool — the existing `get_issue(include="remote_links")` enrichment is the Phase A approach per #1104. The shape improvement benefits both the enrichment path and any future standalone tool.

Keeps our existing dict-response unwrapping (handles `remoteLinks` key + single-dict fallback) which #1190 did not have. Adds `resolved` status field which #1190 dropped.

### Roadmap alignment

- **Phase A:** Improves existing `include="remote_links"` enrichment shape — aligned
- **Phase B:** N/A
- **Phase C:** Does not add standalone tool — aligned with #1201 which says this should use the `include` param approach

## Test plan

- [x] 8 remote link tests (2 new: input validation, unexpected response; 6 updated for simplified shape)
- [x] Full suite: 2890 passed, 0 failures, 0 warnings (`-W error`)
- [x] Pre-commit clean

Closes #287