### PR TITLE
feat(auth): add service account support via Cloud ID (closes #291)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,23 @@ JIRA_API_TOKEN=your_jira_api_token_here
 CONFLUENCE_USERNAME=your.email@example.com
 CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 
+# --- METHOD 1b: SERVICE ACCOUNT (Atlassian Cloud - API Token with Cloud ID) ---
+# Service accounts use the api.atlassian.com gateway instead of direct instance URLs.
+# This is useful when AI agents should act under a dedicated bot identity.
+# 1. Create a service account at: https://admin.atlassian.com
+# 2. Generate an API token for the service account
+# 3. Get your Cloud ID from: https://your-company.atlassian.net/_edge/tenant_info
+#    (look for the "cloudId" field in the JSON response)
+# When CLOUD_ID is set, JIRA_URL/CONFLUENCE_URL are optional (the gateway URL is derived).
+#ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
+#JIRA_USERNAME=service-account@your-company.atlassian.net
+#JIRA_API_TOKEN=service_account_api_token
+#CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+#CONFLUENCE_API_TOKEN=service_account_api_token
+# You can also set per-service Cloud IDs if Jira and Confluence are on different sites:
+#JIRA_CLOUD_ID=your-jira-cloud-id
+#CONFLUENCE_CLOUD_ID=your-confluence-cloud-id
+
 # --- METHOD 2: PERSONAL ACCESS TOKEN (PAT) (Server / Data Center - Recommended) ---
 # Create PATs in your Jira/Confluence profile settings (usually under "Personal Access Tokens").
 #JIRA_PERSONAL_TOKEN=your_jira_personal_access_token

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Authentication"
-description: "Configure authentication for MCP Atlassian — API tokens, PATs, and OAuth 2.0"
+description: "Configure authentication for MCP Atlassian — API tokens, service accounts, PATs, and OAuth 2.0"
 ---
 
 MCP Atlassian supports three authentication methods depending on your Atlassian deployment type.
@@ -31,6 +31,36 @@ CONFLUENCE_URL=https://your-company.atlassian.net/wiki
 CONFLUENCE_USERNAME=your.email@company.com
 CONFLUENCE_API_TOKEN=your_api_token
 ```
+
+## Service Account (Cloud)
+
+For AI agents and automations that should act under a dedicated bot identity instead of a personal account.
+
+<Steps>
+  <Step title="Create Service Account">
+    Go to [Atlassian Admin](https://admin.atlassian.com) → **Directory** → **Service accounts** and create a new service account
+  </Step>
+  <Step title="Generate API Token">
+    Generate an API token for the service account
+  </Step>
+  <Step title="Get Cloud ID">
+    Visit `https://your-company.atlassian.net/_edge/tenant_info` and copy the `cloudId` value from the JSON response
+  </Step>
+</Steps>
+
+**Environment variables:**
+```bash
+ATLASSIAN_CLOUD_ID=your-cloud-id-uuid
+JIRA_USERNAME=service-account@your-company.atlassian.net
+JIRA_API_TOKEN=service_account_api_token
+CONFLUENCE_USERNAME=service-account@your-company.atlassian.net
+CONFLUENCE_API_TOKEN=service_account_api_token
+```
+
+<Note>
+When `ATLASSIAN_CLOUD_ID` is set, `JIRA_URL` and `CONFLUENCE_URL` are optional — the server routes requests through the `api.atlassian.com` gateway automatically.
+You can also use `JIRA_CLOUD_ID` and `CONFLUENCE_CLOUD_ID` separately if your Jira and Confluence are on different Cloud sites.
+</Note>
 
 ## Personal Access Token (Server/Data Center)
 

--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -76,11 +76,11 @@ class ConfluenceClient:
         elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Confluence client with Token (PAT) auth. "
-                f"URL: {self.config.url}, "
+                f"URL: {self.config.api_url}, "
                 f"Token (masked): {mask_sensitive(str(self.config.personal_token))}"
             )
             self.confluence = Confluence(
-                url=self.config.url,
+                url=self.config.api_url,
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
@@ -89,12 +89,12 @@ class ConfluenceClient:
         else:  # basic auth
             logger.debug(
                 f"Initializing Confluence client with Basic auth. "
-                f"URL: {self.config.url}, Username: {self.config.username}, "
+                f"URL: {self.config.api_url}, Username: {self.config.username}, "
                 f"API Token present: {bool(self.config.api_token)}, "
                 f"Is Cloud: {self.config.is_cloud}"
             )
             self.confluence = Confluence(
-                url=self.config.url,
+                url=self.config.api_url,
                 username=self.config.username,
                 password=self.config.api_token,  # API token is used as password
                 cloud=self.config.is_cloud,

--- a/src/mcp_atlassian/confluence/config.py
+++ b/src/mcp_atlassian/confluence/config.py
@@ -41,6 +41,9 @@ class ConfluenceConfig:
     client_key_password: str | None = None  # Password for encrypted private key
     timeout: int = 75  # Connection timeout in seconds
     cookie: str | None = None  # Raw cookie string to attach to all requests
+    cloud_id: str | None = (
+        None  # Cloud ID — routes via api.atlassian.com (CONFLUENCE_CLOUD_ID > ATLASSIAN_CLOUD_ID)
+    )
 
     @property
     def is_cloud(self) -> bool:
@@ -50,6 +53,10 @@ class ConfluenceConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
+        # cloud_id set directly on config means Cloud (service account or explicit)
+        if self.cloud_id:
+            return True
+
         # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
@@ -72,6 +79,17 @@ class ConfluenceConfig:
         return is_atlassian_cloud_url(self.url) if self.url else False
 
     @property
+    def api_url(self) -> str:
+        """Get the effective API URL, using the Cloud gateway when cloud_id is set.
+
+        Returns:
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+        """
+        if self.cloud_id:
+            return f"https://api.atlassian.com/ex/confluence/{self.cloud_id}"
+        return self.url
+
+    @property
     def verify_ssl(self) -> bool:
         """Compatibility property for old code.
 
@@ -91,7 +109,11 @@ class ConfluenceConfig:
             ValueError: If any required environment variable is missing
         """
         url = os.getenv("CONFLUENCE_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        # cloud_id can substitute for URL (service accounts use api.atlassian.com)
+        has_cloud_id = bool(
+            os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+        )
+        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required CONFLUENCE_URL environment variable. "
                 "Set CONFLUENCE_URL to your Confluence base URL, for example "
@@ -111,7 +133,7 @@ class ConfluenceConfig:
         auth_type = None
 
         # Use the shared utility function directly
-        is_cloud = is_atlassian_cloud_url(url) if url else False
+        is_cloud = has_cloud_id or (is_atlassian_cloud_url(url) if url else False)
 
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
@@ -191,6 +213,9 @@ class ConfluenceConfig:
         # Cookie configuration
         cookie = os.getenv("CONFLUENCE_COOKIE")
 
+        # Cloud ID for service accounts (CONFLUENCE_CLOUD_ID takes precedence over ATLASSIAN_CLOUD_ID)
+        cloud_id = os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -210,6 +235,7 @@ class ConfluenceConfig:
             client_key_password=client_key_password,
             timeout=timeout,
             cookie=cookie,
+            cloud_id=cloud_id,
         )
 
     def is_auth_configured(self) -> bool:

--- a/src/mcp_atlassian/jira/client.py
+++ b/src/mcp_atlassian/jira/client.py
@@ -90,11 +90,11 @@ class JiraClient:
         elif self.config.auth_type == "pat":
             logger.debug(
                 f"Initializing Jira client with Token (PAT) auth. "
-                f"URL: {self.config.url}, "
+                f"URL: {self.config.api_url}, "
                 f"Token (masked): {mask_sensitive(str(self.config.personal_token))}"
             )
             self.jira = Jira(
-                url=self.config.url,
+                url=self.config.api_url,
                 token=self.config.personal_token,
                 cloud=self.config.is_cloud,
                 verify_ssl=self.config.ssl_verify,
@@ -103,12 +103,12 @@ class JiraClient:
         else:  # basic auth
             logger.debug(
                 f"Initializing Jira client with Basic auth. "
-                f"URL: {self.config.url}, Username: {self.config.username}, "
+                f"URL: {self.config.api_url}, Username: {self.config.username}, "
                 f"API Token present: {bool(self.config.api_token)}, "
                 f"Is Cloud: {self.config.is_cloud}"
             )
             self.jira = Jira(
-                url=self.config.url,
+                url=self.config.api_url,
                 username=self.config.username,
                 password=self.config.api_token,
                 cloud=self.config.is_cloud,

--- a/src/mcp_atlassian/jira/config.py
+++ b/src/mcp_atlassian/jira/config.py
@@ -117,6 +117,9 @@ class JiraConfig:
     sla_config: SLAConfig | None = None  # Optional SLA configuration
     timeout: int = 75  # Connection timeout in seconds
     cookie: str | None = None  # Raw cookie string to attach to all requests
+    cloud_id: str | None = (
+        None  # Cloud ID — routes via api.atlassian.com (JIRA_CLOUD_ID > ATLASSIAN_CLOUD_ID)
+    )
 
     @property
     def is_cloud(self) -> bool:
@@ -126,6 +129,10 @@ class JiraConfig:
             True if this is a cloud instance (atlassian.net), False otherwise.
             Localhost URLs are always considered non-cloud (Server/Data Center).
         """
+        # cloud_id set directly on config means Cloud (service account or explicit)
+        if self.cloud_id:
+            return True
+
         # OAuth with cloud_id uses api.atlassian.com which is always Cloud
         if (
             self.auth_type == "oauth"
@@ -148,6 +155,17 @@ class JiraConfig:
         return is_atlassian_cloud_url(self.url) if self.url else False
 
     @property
+    def api_url(self) -> str:
+        """Get the effective API URL, using the Cloud gateway when cloud_id is set.
+
+        Returns:
+            The api.atlassian.com gateway URL if cloud_id is set, otherwise the base URL.
+        """
+        if self.cloud_id:
+            return f"https://api.atlassian.com/ex/jira/{self.cloud_id}"
+        return self.url
+
+    @property
     def verify_ssl(self) -> bool:
         """Compatibility property for old code.
 
@@ -167,7 +185,11 @@ class JiraConfig:
             ValueError: If required environment variables are missing or invalid
         """
         url = os.getenv("JIRA_URL")
-        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE"):
+        # cloud_id can substitute for URL (service accounts use api.atlassian.com)
+        has_cloud_id = bool(
+            os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+        )
+        if not url and not os.getenv("ATLASSIAN_OAUTH_ENABLE") and not has_cloud_id:
             error_msg = (
                 "Missing required JIRA_URL environment variable. "
                 "Set JIRA_URL to your Jira base URL, for example "
@@ -185,7 +207,7 @@ class JiraConfig:
         auth_type = None
 
         # Use the shared utility function directly
-        is_cloud = is_atlassian_cloud_url(url) if url else False
+        is_cloud = has_cloud_id or (is_atlassian_cloud_url(url) if url else False)
 
         if is_cloud:
             # Cloud: OAuth takes priority, then basic auth
@@ -266,6 +288,9 @@ class JiraConfig:
         # Cookie configuration
         cookie = os.getenv("JIRA_COOKIE")
 
+        # Cloud ID for service accounts (JIRA_CLOUD_ID takes precedence over ATLASSIAN_CLOUD_ID)
+        cloud_id = os.getenv("JIRA_CLOUD_ID") or os.getenv("ATLASSIAN_CLOUD_ID")
+
         return cls(
             url=url or "",
             auth_type=auth_type,
@@ -286,6 +311,7 @@ class JiraConfig:
             client_key_password=client_key_password,
             timeout=timeout,
             cookie=cookie,
+            cloud_id=cloud_id,
         )
 
     def is_auth_configured(self) -> bool:

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -459,3 +459,86 @@ def test_confluence_fetcher_mro_order():
     # Verify that attachment methods are accessible (the real test)
     assert hasattr(ConfluenceFetcher, "upload_attachment")
     assert hasattr(ConfluenceFetcher, "get_content_attachments")
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_basic_auth_with_cloud_id():
+    """Test that basic auth with cloud_id routes through api.atlassian.com."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="svc_token",
+        cloud_id="test-cloud-uuid",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            username="svc@company.atlassian.net",
+            password="svc_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_pat_auth_with_cloud_id():
+    """Test that PAT auth with cloud_id routes through api.atlassian.com."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="pat",
+        personal_token="test_pat",
+        cloud_id="test-cloud-uuid",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://api.atlassian.com/ex/confluence/test-cloud-uuid",
+            token="test_pat",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_basic_auth_without_cloud_id_uses_direct_url():
+    """Test that basic auth without cloud_id uses the direct URL as before."""
+    config = ConfluenceConfig(
+        url="https://company.atlassian.net/wiki",
+        auth_type="basic",
+        username="user@example.com",
+        api_token="token",
+    )
+
+    with (
+        patch("mcp_atlassian.confluence.client.Confluence") as mock_confluence,
+        patch("mcp_atlassian.preprocessing.confluence.ConfluencePreprocessor"),
+        patch("mcp_atlassian.confluence.client.configure_ssl_verification"),
+    ):
+        ConfluenceClient(config=config)
+
+        mock_confluence.assert_called_once_with(
+            url="https://company.atlassian.net/wiki",
+            username="user@example.com",
+            password="token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )

--- a/tests/unit/confluence/test_config.py
+++ b/tests/unit/confluence/test_config.py
@@ -358,3 +358,71 @@ def test_from_env_without_cookie():
     ):
         config = ConfluenceConfig.from_env()
         assert config.cookie is None
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_service_account_with_cloud_id():
+    """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "test-cloud-uuid",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.auth_type == "basic"
+        assert config.is_cloud is True
+        assert config.username == "svc@company.atlassian.net"
+
+
+def test_from_env_service_account_with_confluence_cloud_id():
+    """Test service-specific CONFLUENCE_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "global-cloud-id",
+            "CONFLUENCE_CLOUD_ID": "confluence-specific-cloud-id",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "confluence-specific-cloud-id"
+
+
+def test_from_env_service_account_no_url_required():
+    """Test that CONFLUENCE_URL is not required when cloud_id is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "CONFLUENCE_CLOUD_ID": "test-cloud-uuid",
+            "CONFLUENCE_USERNAME": "svc@company.atlassian.net",
+            "CONFLUENCE_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        # Should not raise ValueError about missing URL
+        config = ConfluenceConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == ""
+
+
+def test_is_cloud_with_cloud_id_basic_auth():
+    """Test is_cloud returns True when cloud_id is set, regardless of URL."""
+    config = ConfluenceConfig(
+        url="",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -396,3 +396,83 @@ def test_jira_client_basic_auth_preserves_trust_env():
         JiraClient(config=config)
 
         assert mock_session.trust_env is True
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_basic_auth_with_cloud_id():
+    """Test that basic auth with cloud_id routes through api.atlassian.com."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="basic",
+            username="svc@company.atlassian.net",
+            api_token="svc_token",
+            cloud_id="test-cloud-uuid",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://api.atlassian.com/ex/jira/test-cloud-uuid",
+            username="svc@company.atlassian.net",
+            password="svc_token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_pat_auth_with_cloud_id():
+    """Test that PAT auth with cloud_id routes through api.atlassian.com."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="pat",
+            personal_token="test_pat",
+            cloud_id="test-cloud-uuid",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://api.atlassian.com/ex/jira/test-cloud-uuid",
+            token="test_pat",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )
+
+
+def test_init_basic_auth_without_cloud_id_uses_direct_url():
+    """Test that basic auth without cloud_id uses the direct URL as before."""
+    with (
+        patch("mcp_atlassian.jira.client.Jira") as mock_jira,
+        patch("mcp_atlassian.jira.client.configure_ssl_verification"),
+    ):
+        config = JiraConfig(
+            url="https://company.atlassian.net",
+            auth_type="basic",
+            username="user@example.com",
+            api_token="token",
+        )
+
+        JiraClient(config=config)
+
+        mock_jira.assert_called_once_with(
+            url="https://company.atlassian.net",
+            username="user@example.com",
+            password="token",
+            cloud=True,
+            verify_ssl=True,
+            timeout=75,
+        )

--- a/tests/unit/jira/test_config.py
+++ b/tests/unit/jira/test_config.py
@@ -430,3 +430,99 @@ def test_from_env_without_cookie():
     ):
         config = JiraConfig.from_env()
         assert config.cookie is None
+
+
+# ---------------------------------------------------------------------------
+# Service account (cloud_id) tests
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_service_account_with_cloud_id():
+    """Test service account config with ATLASSIAN_CLOUD_ID and basic auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.auth_type == "basic"
+        assert config.is_cloud is True
+        assert config.username == "svc@company.atlassian.net"
+
+
+def test_from_env_service_account_with_jira_cloud_id():
+    """Test service-specific JIRA_CLOUD_ID takes priority over ATLASSIAN_CLOUD_ID."""
+    with patch.dict(
+        os.environ,
+        {
+            "ATLASSIAN_CLOUD_ID": "global-cloud-id",
+            "JIRA_CLOUD_ID": "jira-specific-cloud-id",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "jira-specific-cloud-id"
+
+
+def test_from_env_service_account_no_url_required():
+    """Test that JIRA_URL is not required when cloud_id is set."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        # Should not raise ValueError about missing URL
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == ""
+
+
+def test_from_env_service_account_with_url():
+    """Test service account config with both cloud_id and URL."""
+    with patch.dict(
+        os.environ,
+        {
+            "JIRA_URL": "https://company.atlassian.net",
+            "JIRA_CLOUD_ID": "test-cloud-uuid",
+            "JIRA_USERNAME": "svc@company.atlassian.net",
+            "JIRA_API_TOKEN": "svc_token",
+        },
+        clear=True,
+    ):
+        config = JiraConfig.from_env()
+        assert config.cloud_id == "test-cloud-uuid"
+        assert config.url == "https://company.atlassian.net"
+        assert config.is_cloud is True
+
+
+def test_is_cloud_with_cloud_id_basic_auth():
+    """Test is_cloud returns True when cloud_id is set, regardless of URL."""
+    config = JiraConfig(
+        url="",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True
+
+    # Even with a server-like URL, cloud_id means Cloud
+    config = JiraConfig(
+        url="https://jira.example.com",
+        auth_type="basic",
+        username="svc@company.atlassian.net",
+        api_token="token",
+        cloud_id="test-cloud-uuid",
+    )
+    assert config.is_cloud is True


### PR DESCRIPTION
## Summary

Integrates upstream PR [sooperset/mcp-atlassian#1193](https://github.com/sooperset/mcp-atlassian/pull/1193) (clwluvw) with conflict resolution and improved comments.

- **Cloud ID routing:** `ATLASSIAN_CLOUD_ID` (or `JIRA_CLOUD_ID`/`CONFLUENCE_CLOUD_ID`) routes requests through `api.atlassian.com` gateway for service accounts
- **URL optional:** `JIRA_URL`/`CONFLUENCE_URL` no longer required when cloud_id is set
- **is_cloud:** Returns true when cloud_id is present
- **Improved comments:** Clarified env var precedence (`JIRA_CLOUD_ID` > `ATLASSIAN_CLOUD_ID`) in field comments and `from_env` logic — the original PR buried this behavior

### Roadmap alignment

- **Phase A:** N/A — auth/config infrastructure
- **Phase B:** N/A
- **Phase C:** N/A

## Test plan

- [x] 15 new tests (config: env parsing, precedence, no-URL-required, is_cloud; client: basic+PAT with/without cloud_id)
- [x] Full suite: 2914 passed, 0 failures, 0 warnings (`-W error`)
- [x] Pre-commit clean
- [x] Security review: reads cloud_id from env, constructs gateway URL deterministically, no credential exposure

Closes #291