### PR TITLE
fix(confluence): use POST instead of PUT for DC attachment upload (closes #294)

### DIFF
--- a/src/mcp_atlassian/confluence/attachments.py
+++ b/src/mcp_atlassian/confluence/attachments.py
@@ -484,10 +484,8 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             if minor_edit is not None:
                 data["minorEdit"] = str(minor_edit).lower()
 
-            # Use PUT to support creating new versions of existing attachments
-            # PUT will create a new attachment if it doesn't exist, OR create a new
-            # version if an attachment with the same filename already exists
-            response = self.confluence._session.put(
+            # POST creates a new attachment or a new version if same filename exists
+            response = self.confluence._session.post(
                 url, headers=headers, files=files, data=data
             )
             response.raise_for_status()
@@ -502,8 +500,11 @@ class AttachmentsMixin(ConfluenceClient, AttachmentsOperationsProto):
             return result
 
         except Exception as e:
-            logger.error(f"Direct API upload failed: {e}")
-            return None
+            logger.error(
+                f"Direct API upload failed: {type(e).__name__}: {e}", exc_info=True
+            )
+            # Propagate error details instead of swallowing them
+            raise
         finally:
             # Close file handles (only for actual file objects, not text fields like comment)
             if "files" in locals() and "file" in files:

--- a/tests/unit/confluence/test_attachments.py
+++ b/tests/unit/confluence/test_attachments.py
@@ -104,13 +104,11 @@ class TestAttachmentsMixin:
 
         mock_response = Mock()
         if raise_error:
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.side_effect = raise_error
+            attachments_mixin.confluence._session.post.side_effect = raise_error
         else:
             mock_response.json.return_value = response_data
             mock_response.raise_for_status.return_value = None
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.return_value = mock_response
+            attachments_mixin.confluence._session.post.return_value = mock_response
 
         return mock_response
 
@@ -152,9 +150,8 @@ class TestAttachmentsMixin:
             assert result["id"] == "att12345"
 
             # Verify the REST API was called with correct parameters
-            # Changed from .post to .put to match implementation
-            attachments_mixin.confluence._session.put.assert_called_once()
-            call_args = attachments_mixin.confluence._session.put.call_args
+            attachments_mixin.confluence._session.post.assert_called_once()
+            call_args = attachments_mixin.confluence._session.post.call_args
 
             # Check URL
             assert "/rest/api/content/123456/child/attachment" in call_args[0][0]
@@ -266,10 +263,9 @@ class TestAttachmentsMixin:
                 "123456", "/absolute/path/test_file.txt"
             )
 
-            # Assertions
+            # Assertions: exception is caught by upload_attachment and returned as failure dict
             assert result["success"] is False
-            # When direct API fails, we get generic failure message
-            assert "Failed to upload attachment" in result["error"]
+            assert "API Error" in result["error"]
 
     # Tests for upload_attachments method
 


### PR DESCRIPTION
## Summary

Integrates upstream PR [sooperset/mcp-atlassian#1202](https://github.com/sooperset/mcp-atlassian/pull/1202) (danielfrey63) as-is.

- PUT → POST for `/rest/api/content/{id}/child/attachment` — DC rejects PUT with 405
- Propagates exceptions instead of swallowing to `None` (aligns with #1090 lessons)

### Roadmap alignment
- **Phase A/B/C:** N/A — bug fix

## Test plan
- [x] 52 attachment tests pass
- [x] Pre-commit clean
- [x] Security review: changes HTTP method only, no auth/credential changes

Closes #294

Closes #265