### PR TITLE
feat(ssl): add opt-in legacy TLS support for older corporate servers (closes #300)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,11 @@ CONFLUENCE_API_TOKEN=your_confluence_api_token_here
 #CONFLUENCE_SSL_VERIFY=true
 # Set to false to disable OS trust store integration and use the bundled certifi CA bundle instead.
 #MCP_ATLASSIAN_USE_SYSTEM_TRUSTSTORE=true
+# Enable legacy TLS 1.0/1.1 and weak cipher suites for older corporate servers.
+# This is a SEPARATE risk decision from SSL_VERIFY=false — it widens protocol/cipher
+# negotiation beyond just disabling certificate verification. Only enable if your
+# server does not support modern TLS.
+#SSL_LEGACY_TLS=false
 
 # --- CLIENT CERTIFICATE AUTHENTICATION (mTLS) ---
 # For mutual TLS authentication with Server/DC instances.

--- a/src/mcp_atlassian/utils/ssl.py
+++ b/src/mcp_atlassian/utils/ssl.py
@@ -101,7 +101,20 @@ class SSLIgnoreAdapter(NoProxyAdapter):
             pool_kwargs: Additional arguments for the pool manager
         """
         # Configure SSL context to disable verification completely
-        context = ssl.create_default_context()
+        legacy_tls = os.environ.get("SSL_LEGACY_TLS", "").lower() == "true"
+        if legacy_tls:
+            # Legacy mode for corporate servers that only support TLS 1.0/1.1
+            # and older cipher suites. Must be explicitly opted into.
+            logger.warning(
+                "SSL_LEGACY_TLS is enabled — using legacy TLS versions and cipher "
+                "suites. This weakens transport security and should only be used "
+                "when connecting to servers that do not support modern TLS."
+            )
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+            context.set_ciphers("DEFAULT@SECLEVEL=0")
+        else:
+            context = ssl.create_default_context()
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
 

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -320,3 +320,66 @@ def test_configure_ssl_verification_enabled_with_no_proxy_mounts_adapter(monkeyp
     assert not isinstance(
         session.get_adapter("https://test.example.com"), SSLIgnoreAdapter
     )
+
+
+# ---------------------------------------------------------------------------
+# Legacy TLS support (SSL_LEGACY_TLS env var)
+# ---------------------------------------------------------------------------
+
+
+def test_ssl_ignore_adapter_default_no_legacy_tls():
+    """Without SSL_LEGACY_TLS, init_poolmanager uses create_default_context."""
+    adapter = SSLIgnoreAdapter()
+    mock_pool_manager = MagicMock()
+
+    with (
+        patch("ssl.create_default_context") as mock_create_context,
+        patch("mcp_atlassian.utils.ssl.PoolManager", return_value=mock_pool_manager),
+    ):
+        mock_context = MagicMock()
+        mock_create_context.return_value = mock_context
+
+        adapter.init_poolmanager(5, 10)
+
+        mock_create_context.assert_called_once()
+        mock_context.set_ciphers.assert_not_called()
+
+
+def test_ssl_ignore_adapter_legacy_tls_enabled(monkeypatch):
+    """With SSL_LEGACY_TLS=true, init_poolmanager enables legacy TLS/ciphers."""
+    monkeypatch.setenv("SSL_LEGACY_TLS", "true")
+    adapter = SSLIgnoreAdapter()
+    mock_pool_manager = MagicMock()
+
+    with (
+        patch("ssl.SSLContext") as mock_ssl_context,
+        patch("mcp_atlassian.utils.ssl.PoolManager", return_value=mock_pool_manager),
+    ):
+        mock_context = MagicMock()
+        mock_ssl_context.return_value = mock_context
+
+        adapter.init_poolmanager(5, 10)
+
+        mock_ssl_context.assert_called_once_with(ssl.PROTOCOL_TLS_CLIENT)
+        assert mock_context.check_hostname is False
+        assert mock_context.verify_mode == ssl.CERT_NONE
+        mock_context.set_ciphers.assert_called_once_with("DEFAULT@SECLEVEL=0")
+
+
+def test_ssl_ignore_adapter_legacy_tls_false_uses_default(monkeypatch):
+    """SSL_LEGACY_TLS=false still uses create_default_context."""
+    monkeypatch.setenv("SSL_LEGACY_TLS", "false")
+    adapter = SSLIgnoreAdapter()
+    mock_pool_manager = MagicMock()
+
+    with (
+        patch("ssl.create_default_context") as mock_create_context,
+        patch("mcp_atlassian.utils.ssl.PoolManager", return_value=mock_pool_manager),
+    ):
+        mock_context = MagicMock()
+        mock_create_context.return_value = mock_context
+
+        adapter.init_poolmanager(5, 10)
+
+        mock_create_context.assert_called_once()
+        mock_context.set_ciphers.assert_not_called()


### PR DESCRIPTION
## Summary

Reworks upstream PR [sooperset/mcp-atlassian#1194](https://github.com/sooperset/mcp-atlassian/pull/1194) (arioko) to gate legacy TLS behind an explicit opt-in.

The original PR applied TLS 1.0/1.1 and `SECLEVEL=0` cipher downgrades unconditionally to all `SSL_VERIFY=false` users. Per our security reviewer's assessment, disabling cert verification is a **different risk decision** from widening protocol/cipher negotiation — the project's pattern (documented in `.env.example`) is to make risky behavior explicit with dedicated env toggles.

### Changes
- **`SSL_LEGACY_TLS=true`** env var gates legacy TLS/cipher support
- When enabled: uses `ssl.SSLContext(PROTOCOL_TLS_CLIENT)` with `MINIMUM_SUPPORTED` + `SECLEVEL=0`, logs a prominent warning
- When not set or false: behavior is unchanged (`ssl.create_default_context`)
- Documented in `.env.example` next to existing SSL settings

### Roadmap alignment
- **Phase A/B/C:** N/A — infrastructure

## Test plan
- [x] 3 new tests: default (no legacy), enabled, explicitly false
- [x] Existing `test_ssl_ignore_adapter_init_poolmanager` unchanged (default path)
- [x] Full suite: 2930 passed, 0 failures, 0 warnings (`-W error`)
- [x] Pre-commit clean
- [x] Security review: opt-in only, prominent warning log, documented as separate risk from SSL_VERIFY

Closes #300