### PR TITLE
fix(confluence): surface duplicate title error on update_page (closes #35)

### DIFF
--- a/src/mcp_atlassian/confluence/pages.py
+++ b/src/mcp_atlassian/confluence/pages.py
@@ -800,6 +800,18 @@ class PagesMixin(ConfluenceClient):
 
             # After update, refresh the page data
             return self.get_page_content(page_id)
+        except HTTPError as http_err:
+            status_code = (
+                http_err.response.status_code if http_err.response is not None else None
+            )
+            if status_code == 409:
+                raise Exception(
+                    f"A page with title '{title}' already exists in "
+                    f"this space. Page titles must be unique within "
+                    f"a space."
+                ) from http_err
+            logger.error(f"Error updating page {page_id}: {http_err}")
+            raise
         except Exception as e:
             logger.error(f"Error updating page {page_id}: {str(e)}")
             raise Exception(f"Failed to update page {page_id}: {str(e)}") from e

--- a/tests/unit/confluence/test_pages.py
+++ b/tests/unit/confluence/test_pages.py
@@ -1,8 +1,9 @@
 """Unit tests for the PagesMixin class."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from requests.exceptions import HTTPError
 
 from mcp_atlassian.confluence.pages import PagesMixin
 from mcp_atlassian.confluence.utils import extract_emoji_from_property
@@ -468,6 +469,17 @@ class TestPagesMixin:
         # Act/Assert
         with pytest.raises(Exception, match="Failed to update page"):
             pages_mixin.update_page("987654321", "Test Page", "<p>Content</p>")
+
+    def test_update_page_duplicate_title_error(self, pages_mixin):
+        """Test that duplicate title gives a clear error, not a generic one."""
+        mock_response = Mock()
+        mock_response.status_code = 409
+        mock_response.text = "A page with this title already exists in the space"
+        http_err = HTTPError(response=mock_response)
+        pages_mixin.confluence.update_page.side_effect = http_err
+
+        with pytest.raises(Exception, match="title.*already exists"):
+            pages_mixin.update_page("987654321", "Duplicate Title", "<p>Content</p>")
 
     def test_update_page_preserves_existing_width_by_default(self, pages_mixin):
         """Test updating a page preserves the current width when none is provided."""


### PR DESCRIPTION
## Summary

When `confluence_update_page` hits a duplicate title (HTTP 409 Conflict), the error now says:

> A page with title 'X' already exists in this space. Page titles must be unique within a space.

Instead of the generic "Failed to update page 987654321".

## Test plan

- [x] New test: `test_update_page_duplicate_title_error` — mocks 409 response, verifies clear error message
- [x] Existing `test_update_page_error` still passes (generic errors unchanged)
- [x] All 9 update_page tests pass
- [x] Full suite: 2946 passed, pre-commit clean

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)