### PR TITLE
fix(confluence): preserve @mentions through markdown round-trip (closes #181)

### DIFF
--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -147,11 +147,20 @@ class BasePreprocessor:
         for user_element in user_mentions:
             user_ref = user_element.find("ri:user")
             if user_ref and user_ref.get("ri:account-id"):
-                # Case 1: Direct user reference without link-body
+                # Case 1a: Direct user reference with account-id (Cloud)
                 account_id = user_ref.get("ri:account-id")
                 if isinstance(account_id, str):
                     self._replace_user_mention(
                         user_element, account_id, confluence_client
+                    )
+                    continue
+
+            if user_ref and user_ref.get("ri:userkey"):
+                # Case 1b: Server/DC user reference with userkey
+                userkey = user_ref.get("ri:userkey")
+                if isinstance(userkey, str):
+                    self._replace_user_mention_by_userkey(
+                        user_element, userkey, confluence_client
                     )
                     continue
 
@@ -164,6 +173,13 @@ class BasePreprocessor:
                     if isinstance(account_id, str):
                         self._replace_user_mention(
                             user_element, account_id, confluence_client
+                        )
+                        continue
+                if user_ref and user_ref.get("ri:userkey"):
+                    userkey = user_ref.get("ri:userkey")
+                    if isinstance(userkey, str):
+                        self._replace_user_mention_by_userkey(
+                            user_element, userkey, confluence_client
                         )
 
     def _process_user_profile_macros_in_soup(
@@ -291,6 +307,41 @@ class BasePreprocessor:
         )
         link_tag.string = f"@user_{account_id}"
         user_element.replace_with(link_tag)
+
+    def _replace_user_mention_by_userkey(
+        self,
+        user_element: Tag,
+        userkey: str,
+        confluence_client: ConfluenceClient | None = None,
+    ) -> None:
+        """Replace a user mention (Server/DC userkey) with a pseudo-link.
+
+        Args:
+            user_element: The HTML element containing the user mention
+            userkey: The user's key (Server/DC)
+            confluence_client: Optional Confluence client for user lookups
+        """
+        try:
+            display_name = None
+            if confluence_client is not None:
+                user_details = confluence_client.get_user_details_by_username(userkey)
+                display_name = user_details.get("displayName", "")
+
+            name = display_name if display_name else f"user_{userkey}"
+            link_tag = Tag(
+                name="a",
+                attrs={"href": f"confluence-user:userKey/{userkey}"},
+            )
+            link_tag.string = f"@{name}"
+            user_element.replace_with(link_tag)
+        except Exception as e:
+            logger.warning(f"Error processing user mention: {str(e)}")
+            link_tag = Tag(
+                name="a",
+                attrs={"href": f"confluence-user:userKey/{userkey}"},
+            )
+            link_tag.string = f"@user_{userkey}"
+            user_element.replace_with(link_tag)
 
     def _find_attachment_url(
         self,

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -244,17 +244,35 @@ class BasePreprocessor:
                 )
 
             if display_name:
-                replacement_text = f"@{display_name}"
-                macro_element.replace_with(replacement_text)
+                identifier = account_id or userkey
+                id_type = "accountId" if account_id else "userKey"
+                link_tag = Tag(
+                    name="a",
+                    attrs={"href": f"confluence-user:{id_type}/{identifier}"},
+                )
+                link_tag.string = f"@{display_name}"
+                macro_element.replace_with(link_tag)
             else:
                 fallback_identifier = (
                     user_identifier_for_log
                     if user_identifier_for_log
                     else "unknown_user"
                 )
-                fallback_text = f"[User Profile: {fallback_identifier}]"
-                macro_element.replace_with(fallback_text)
-                logger.debug(f"Using fallback for user profile macro: {fallback_text}")
+                if fallback_identifier != "unknown_user":
+                    id_type = "accountId" if account_id else "userKey"
+                    link_tag = Tag(
+                        name="a",
+                        attrs={
+                            "href": f"confluence-user:{id_type}/{fallback_identifier}"
+                        },
+                    )
+                    link_tag.string = f"@{fallback_identifier}"
+                    macro_element.replace_with(link_tag)
+                else:
+                    macro_element.replace_with("[User Profile Macro (Unknown)]")
+                logger.debug(
+                    f"Using fallback for user profile macro: {fallback_identifier}"
+                )
 
     def _replace_user_mention(
         self,

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -262,8 +262,12 @@ class BasePreprocessor:
                 )
                 display_name = user_details.get("displayName", "")
                 if display_name:
-                    new_text = f"@{display_name}"
-                    user_element.replace_with(new_text)
+                    link_tag = Tag(
+                        name="a",
+                        attrs={"href": f"confluence-user:accountId/{account_id}"},
+                    )
+                    link_tag.string = f"@{display_name}"
+                    user_element.replace_with(link_tag)
                     return
             # If we don't have a confluence client or couldn't get user details,
             # use fallback
@@ -280,9 +284,13 @@ class BasePreprocessor:
             user_element: The HTML element containing the user mention
             account_id: The user's account ID
         """
-        # Fallback: just use the account ID
-        new_text = f"@user_{account_id}"
-        user_element.replace_with(new_text)
+        # Fallback: use the account ID with a pseudo-link
+        link_tag = Tag(
+            name="a",
+            attrs={"href": f"confluence-user:accountId/{account_id}"},
+        )
+        link_tag.string = f"@user_{account_id}"
+        user_element.replace_with(link_tag)
 
     def _find_attachment_url(
         self,

--- a/src/mcp_atlassian/preprocessing/base.py
+++ b/src/mcp_atlassian/preprocessing/base.py
@@ -12,6 +12,10 @@ from markdownify import markdownify as md
 
 logger = logging.getLogger("mcp-atlassian")
 
+# Pseudo-link scheme for encoding Confluence user mentions in markdown.
+# Read path (base.py) writes these; write path (confluence.py) parses them.
+CONFLUENCE_USER_SCHEME = "confluence-user"
+
 
 def _extract_blocks(
     text: str,
@@ -243,36 +247,36 @@ class BasePreprocessor:
                     "Confluence client not available for User Profile Macro processing."
                 )
 
-            if display_name:
-                identifier = account_id or userkey
-                id_type = "accountId" if account_id else "userKey"
-                link_tag = Tag(
-                    name="a",
-                    attrs={"href": f"confluence-user:{id_type}/{identifier}"},
+            id_type = "accountId" if account_id else "userKey"
+            identifier = account_id or userkey
+
+            if display_name and identifier:
+                macro_element.replace_with(
+                    self._create_user_link_tag(id_type, identifier, display_name)
                 )
-                link_tag.string = f"@{display_name}"
-                macro_element.replace_with(link_tag)
+            elif identifier:
+                macro_element.replace_with(
+                    self._create_user_link_tag(id_type, identifier, identifier)
+                )
+                logger.debug(f"Using fallback for user profile macro: {identifier}")
             else:
-                fallback_identifier = (
-                    user_identifier_for_log
-                    if user_identifier_for_log
-                    else "unknown_user"
-                )
-                if fallback_identifier != "unknown_user":
-                    id_type = "accountId" if account_id else "userKey"
-                    link_tag = Tag(
-                        name="a",
-                        attrs={
-                            "href": f"confluence-user:{id_type}/{fallback_identifier}"
-                        },
-                    )
-                    link_tag.string = f"@{fallback_identifier}"
-                    macro_element.replace_with(link_tag)
-                else:
-                    macro_element.replace_with("[User Profile Macro (Unknown)]")
-                logger.debug(
-                    f"Using fallback for user profile macro: {fallback_identifier}"
-                )
+                macro_element.replace_with("[User Profile Macro (Unknown)]")
+
+    @staticmethod
+    def _create_user_link_tag(id_type: str, id_value: str, display_text: str) -> Tag:
+        """Create a user mention pseudo-link tag.
+
+        Args:
+            id_type: "accountId" or "userKey"
+            id_value: The user's identifier
+            display_text: Text to display (without @ prefix)
+        """
+        link_tag = Tag(
+            name="a",
+            attrs={"href": f"{CONFLUENCE_USER_SCHEME}:{id_type}/{id_value}"},
+        )
+        link_tag.string = f"@{display_text}"
+        return link_tag
 
     def _replace_user_mention(
         self,
@@ -280,51 +284,32 @@ class BasePreprocessor:
         account_id: str,
         confluence_client: ConfluenceClient | None = None,
     ) -> None:
-        """
-        Replace a user mention with the user's display name.
-
-        Args:
-            user_element: The HTML element containing the user mention
-            account_id: The user's account ID
-            confluence_client: Optional Confluence client for user lookups
-        """
+        """Replace a user mention (Cloud account-id) with a pseudo-link."""
         try:
-            # Only attempt to get user details if we have a valid confluence client
             if confluence_client is not None:
                 user_details = confluence_client.get_user_details_by_accountid(
                     account_id
                 )
                 display_name = user_details.get("displayName", "")
                 if display_name:
-                    link_tag = Tag(
-                        name="a",
-                        attrs={"href": f"confluence-user:accountId/{account_id}"},
+                    user_element.replace_with(
+                        self._create_user_link_tag(
+                            "accountId", account_id, display_name
+                        )
                     )
-                    link_tag.string = f"@{display_name}"
-                    user_element.replace_with(link_tag)
                     return
-            # If we don't have a confluence client or couldn't get user details,
-            # use fallback
-            self._use_fallback_user_mention(user_element, account_id)
+            user_element.replace_with(
+                self._create_user_link_tag(
+                    "accountId", account_id, f"user_{account_id}"
+                )
+            )
         except Exception as e:
             logger.warning(f"Error processing user mention: {str(e)}")
-            self._use_fallback_user_mention(user_element, account_id)
-
-    def _use_fallback_user_mention(self, user_element: Tag, account_id: str) -> None:
-        """
-        Replace user mention with a fallback when the API call fails.
-
-        Args:
-            user_element: The HTML element containing the user mention
-            account_id: The user's account ID
-        """
-        # Fallback: use the account ID with a pseudo-link
-        link_tag = Tag(
-            name="a",
-            attrs={"href": f"confluence-user:accountId/{account_id}"},
-        )
-        link_tag.string = f"@user_{account_id}"
-        user_element.replace_with(link_tag)
+            user_element.replace_with(
+                self._create_user_link_tag(
+                    "accountId", account_id, f"user_{account_id}"
+                )
+            )
 
     def _replace_user_mention_by_userkey(
         self,
@@ -332,13 +317,7 @@ class BasePreprocessor:
         userkey: str,
         confluence_client: ConfluenceClient | None = None,
     ) -> None:
-        """Replace a user mention (Server/DC userkey) with a pseudo-link.
-
-        Args:
-            user_element: The HTML element containing the user mention
-            userkey: The user's key (Server/DC)
-            confluence_client: Optional Confluence client for user lookups
-        """
+        """Replace a user mention (Server/DC userkey) with a pseudo-link."""
         try:
             display_name = None
             if confluence_client is not None:
@@ -346,20 +325,14 @@ class BasePreprocessor:
                 display_name = user_details.get("displayName", "")
 
             name = display_name if display_name else f"user_{userkey}"
-            link_tag = Tag(
-                name="a",
-                attrs={"href": f"confluence-user:userKey/{userkey}"},
+            user_element.replace_with(
+                self._create_user_link_tag("userKey", userkey, name)
             )
-            link_tag.string = f"@{name}"
-            user_element.replace_with(link_tag)
         except Exception as e:
             logger.warning(f"Error processing user mention: {str(e)}")
-            link_tag = Tag(
-                name="a",
-                attrs={"href": f"confluence-user:userKey/{userkey}"},
+            user_element.replace_with(
+                self._create_user_link_tag("userKey", userkey, f"user_{userkey}")
             )
-            link_tag.string = f"@user_{userkey}"
-            user_element.replace_with(link_tag)
 
     def _find_attachment_url(
         self,

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     from md2conf.converter import elements_from_strings as elements_from_string
 
-from .base import BasePreprocessor
+from .base import CONFLUENCE_USER_SCHEME, BasePreprocessor
 
 logger = logging.getLogger("mcp-atlassian")
 
@@ -75,11 +75,11 @@ class ConfluencePreprocessor(BasePreprocessor):
                 if child.tag != "a":
                     continue
                 href = child.get("href", "")
-                if not href.startswith("confluence-user:"):
+                scheme_prefix = f"{CONFLUENCE_USER_SCHEME}:"
+                if not href.startswith(scheme_prefix):
                     continue
 
-                # Parse: confluence-user:accountId/XXX or confluence-user:userKey/XXX
-                remainder = href[len("confluence-user:") :]
+                remainder = href[len(scheme_prefix) :]
                 if "/" not in remainder:
                     continue
                 id_type, id_value = remainder.split("/", 1)

--- a/src/mcp_atlassian/preprocessing/confluence.py
+++ b/src/mcp_atlassian/preprocessing/confluence.py
@@ -49,6 +49,64 @@ class ConfluencePreprocessor(BasePreprocessor):
         "default": "default",
     }
 
+    # Confluence XML namespace URIs used by md2conf for element construction.
+    _AC_NS = "http://atlassian.com/content"
+    _RI_NS = "http://atlassian.com/resource/identifier"
+
+    @staticmethod
+    def _reconstruct_mentions(root: "lxml.etree._Element") -> None:  # type: ignore[name-defined]  # noqa: F821
+        """Replace pseudo-link anchors with Confluence mention storage XML.
+
+        Walks the element tree for <a href="confluence-user:..."> nodes
+        and replaces them with <ac:link><ri:user .../></ac:link>.
+
+        Must be called AFTER elements_from_string() and BEFORE
+        converter.visit() to intercept pseudo-links before md2conf's
+        generic link transformer processes them.
+        """
+        from lxml import etree
+
+        ac_ns = ConfluencePreprocessor._AC_NS
+        ri_ns = ConfluencePreprocessor._RI_NS
+
+        for parent in root.iter():
+            children = list(parent)
+            for i, child in enumerate(children):
+                if child.tag != "a":
+                    continue
+                href = child.get("href", "")
+                if not href.startswith("confluence-user:"):
+                    continue
+
+                # Parse: confluence-user:accountId/XXX or confluence-user:userKey/XXX
+                remainder = href[len("confluence-user:") :]
+                if "/" not in remainder:
+                    continue
+                id_type, id_value = remainder.split("/", 1)
+
+                # Build Confluence storage XML using lxml with proper namespaces
+                ac_link = etree.Element(etree.QName(ac_ns, "link"))
+                ri_user = etree.SubElement(ac_link, etree.QName(ri_ns, "user"))
+                if id_type == "accountId":
+                    ri_user.set(etree.QName(ri_ns, "account-id"), id_value)
+                elif id_type == "userKey":
+                    ri_user.set(etree.QName(ri_ns, "userkey"), id_value)
+                else:
+                    continue
+
+                # Add link body with display text
+                display_text = child.text or ""
+                ac_link_body = etree.SubElement(
+                    ac_link, etree.QName(ac_ns, "link-body")
+                )
+                ac_link_body.text = display_text
+
+                # Preserve trailing text after the link
+                ac_link.tail = child.tail
+
+                # Replace the <a> node in parent's children
+                parent[i] = ac_link
+
     def markdown_to_confluence_storage(
         self,
         markdown_content: str,
@@ -84,6 +142,9 @@ class ConfluencePreprocessor(BasePreprocessor):
             try:
                 # Parse the HTML into an element tree
                 root = elements_from_string(html_content)
+
+                # Reconstruct Confluence mentions from pseudo-links
+                self._reconstruct_mentions(root)
 
                 # Create converter options
                 options = ConfluenceConverterOptions(

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -130,6 +130,20 @@ def test_mention_preserves_account_id_as_pseudo_link(preprocessor_with_confluenc
     assert "[@Test User abc123](confluence-user:accountId/abc123)" in processed_markdown
 
 
+def test_mention_preserves_userkey_as_pseudo_link(preprocessor_with_confluence):
+    """Server/DC mentions with ri:userkey emit pseudo-links."""
+    html = """
+    <ac:link>
+        <ri:user ri:userkey="jsmith"/>
+    </ac:link>
+    """
+    _, processed_markdown = preprocessor_with_confluence.process_html_content(
+        html, confluence_client=MockConfluenceClient()
+    )
+
+    assert "[@Test User jsmith](confluence-user:userKey/jsmith)" in processed_markdown
+
+
 def test_clean_jira_text_empty(preprocessor_with_jira):
     """Test cleaning empty Jira text."""
     assert preprocessor_with_jira.clean_jira_text("") == ""

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -1635,3 +1635,39 @@ def test_normal_links_not_affected_by_mention_reconstruction():
 
     assert "example.com/docs" in storage
     assert "ri:user" not in storage
+
+
+def test_malformed_pseudo_links_ignored_on_write():
+    """Malformed confluence-user: links should pass through unchanged."""
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+
+    # Missing slash separator
+    storage = preprocessor.markdown_to_confluence_storage(
+        "See [@Bad](confluence-user:badformat) here."
+    )
+    assert "ri:user" not in storage
+
+    # Unknown id type
+    storage = preprocessor.markdown_to_confluence_storage(
+        "See [@Bad](confluence-user:unknownType/abc) here."
+    )
+    assert "ri:user" not in storage
+
+
+def test_profile_macro_userkey_fallback_without_lookup():
+    """Profile macro with ri:userkey and no client falls back to pseudo-link with identifier."""
+    html = (
+        "<p>Mentioned "
+        '<ac:structured-macro ac:name="profile" ac:schema-version="1">'
+        '<ac:parameter ac:name="user">'
+        '<ri:user ri:userkey="serveruser42" />'
+        "</ac:parameter>"
+        "</ac:structured-macro>.</p>"
+    )
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    _, processed_markdown = preprocessor.process_html_content(
+        html, confluence_client=None
+    )
+
+    assert "[@serveruser42](confluence-user:userKey/serveruser42)" in processed_markdown

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -489,8 +489,38 @@ def test_process_confluence_profile_macro_fallback():
     processed_html, processed_markdown = preprocessor.process_html_content(
         html, confluence_client=None
     )
-    assert "[User Profile: user999]" in processed_html
-    assert "[User Profile: user999]" in processed_markdown
+    assert 'href="confluence-user:accountId/user999"' in processed_html
+    assert "[@user999](confluence-user:accountId/user999)" in processed_markdown
+
+
+def test_profile_macro_preserves_account_id_as_pseudo_link():
+    """Profile macros should emit pseudo-links preserving the account ID."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    html = (
+        "<p>Assigned to "
+        '<ac:structured-macro ac:name="profile" ac:schema-version="1">'
+        '<ac:parameter ac:name="user">'
+        '<ri:user ri:account-id="prof-acct-123" />'
+        "</ac:parameter>"
+        "</ac:structured-macro>.</p>"
+    )
+
+    class CustomMock:
+        def get_user_details_by_accountid(self, account_id):
+            return {"displayName": "Profile User"}
+
+        def get_user_details_by_username(self, username):
+            return {}
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    _, processed_markdown = preprocessor.process_html_content(
+        html, confluence_client=CustomMock()
+    )
+
+    assert (
+        "[@Profile User](confluence-user:accountId/prof-acct-123)" in processed_markdown
+    )
 
 
 def test_process_user_profile_macro_multiple():
@@ -532,10 +562,16 @@ def test_process_user_profile_macro_multiple():
     processed_html, processed_markdown = preprocessor.process_html_content(
         html, confluence_client=CustomMockConfluenceClient()
     )
-    assert "@Test User One" in processed_html
-    assert "@Test User Two" in processed_html
-    assert "@Test User One" in processed_markdown
-    assert "@Test User Two" in processed_markdown
+    assert 'href="confluence-user:accountId/test-account-id-123"' in processed_html
+    assert 'href="confluence-user:userKey/test-userkey-456"' in processed_html
+    assert (
+        "[@Test User One](confluence-user:accountId/test-account-id-123)"
+        in processed_markdown
+    )
+    assert (
+        "[@Test User Two](confluence-user:userKey/test-userkey-456)"
+        in processed_markdown
+    )
 
 
 def test_markdown_to_confluence_no_automatic_anchors():

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -112,8 +112,22 @@ def test_process_html_content_with_user_mentions(preprocessor_with_confluence):
         )
     )
 
-    assert "@Test User 123456" in processed_html
-    assert "@Test User 123456" in processed_markdown
+    assert 'href="confluence-user:accountId/123456"' in processed_html
+    assert "[@Test User 123456](confluence-user:accountId/123456)" in processed_markdown
+
+
+def test_mention_preserves_account_id_as_pseudo_link(preprocessor_with_confluence):
+    """Mentions should emit markdown pseudo-links preserving the account ID."""
+    html = """
+    <ac:link>
+        <ri:user ri:account-id="abc123"/>
+    </ac:link>
+    """
+    _, processed_markdown = preprocessor_with_confluence.process_html_content(
+        html, confluence_client=MockConfluenceClient()
+    )
+
+    assert "[@Test User abc123](confluence-user:accountId/abc123)" in processed_markdown
 
 
 def test_clean_jira_text_empty(preprocessor_with_jira):

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -1552,3 +1552,29 @@ class TestHtmlConversionCodeProtection:
         """Direct test of _convert_html_to_markdown with markdown code spans."""
         result = preprocessor._convert_html_to_markdown(md_input)
         assert expected_substr in result, f"Expected '{expected_substr}' in: {result!r}"
+
+
+def test_markdown_to_storage_reconstructs_account_id_mention():
+    """Pseudo-link mentions should be reconstructed as Confluence storage XML."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    markdown = "Assigned to [@John Smith](confluence-user:accountId/abc123)."
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    storage = preprocessor.markdown_to_confluence_storage(markdown)
+
+    assert 'ri:account-id="abc123"' in storage
+    assert "<ac:link>" in storage
+    assert "John Smith" in storage
+
+
+def test_markdown_to_storage_reconstructs_userkey_mention():
+    """Pseudo-link mentions with userKey should reconstruct ri:userkey."""
+    from mcp_atlassian.preprocessing.confluence import ConfluencePreprocessor
+
+    markdown = "Assigned to [@Jane Doe](confluence-user:userKey/jdoe)."
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    storage = preprocessor.markdown_to_confluence_storage(markdown)
+
+    assert 'ri:userkey="jdoe"' in storage
+    assert "<ac:link>" in storage
+    assert "Jane Doe" in storage

--- a/tests/unit/preprocessing/test_preprocessing.py
+++ b/tests/unit/preprocessing/test_preprocessing.py
@@ -1578,3 +1578,60 @@ def test_markdown_to_storage_reconstructs_userkey_mention():
     assert 'ri:userkey="jdoe"' in storage
     assert "<ac:link>" in storage
     assert "Jane Doe" in storage
+
+
+def test_mention_round_trip_preserves_identity():
+    """Storage->markdown->storage should preserve the user account ID."""
+    storage_input = (
+        "<p>Check with "
+        '<ac:link><ri:user ri:account-id="round-trip-id"/>'
+        "<ac:link-body>@Round Trip User</ac:link-body></ac:link>"
+        " about this.</p>"
+    )
+
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+
+    # Read: storage -> markdown
+    _, markdown = preprocessor.process_html_content(
+        storage_input, confluence_client=MockConfluenceClient()
+    )
+
+    # The markdown should contain the pseudo-link
+    assert "confluence-user:accountId/round-trip-id" in markdown
+
+    # Write: markdown -> storage
+    storage_output = preprocessor.markdown_to_confluence_storage(markdown)
+
+    # The storage should have the account ID back
+    assert 'ri:account-id="round-trip-id"' in storage_output
+
+
+def test_plain_at_mention_passes_through_on_write():
+    """Plain @Name text (no pseudo-link) should not be converted to a mention."""
+    markdown = "Talk to @John Smith about this."
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    storage = preprocessor.markdown_to_confluence_storage(markdown)
+
+    # Should NOT contain any ri:user or ac:link
+    assert "ri:user" not in storage
+    assert "ri:account-id" not in storage
+    assert "@John Smith" in storage
+
+
+def test_mention_with_bold_formatting_round_trips():
+    """Bold-wrapped mentions should preserve identity through round-trip."""
+    markdown = "Assigned to **[@John Smith](confluence-user:accountId/bold-test-id)**."
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    storage = preprocessor.markdown_to_confluence_storage(markdown)
+
+    assert 'ri:account-id="bold-test-id"' in storage
+
+
+def test_normal_links_not_affected_by_mention_reconstruction():
+    """Regular markdown links should pass through unchanged."""
+    markdown = "See [the docs](https://example.com/docs) for details."
+    preprocessor = ConfluencePreprocessor(base_url="https://example.atlassian.net")
+    storage = preprocessor.markdown_to_confluence_storage(markdown)
+
+    assert "example.com/docs" in storage
+    assert "ri:user" not in storage


### PR DESCRIPTION
## Summary

Confluence @mentions (`<ac:link><ri:user .../></ac:link>`) were being flattened to plain `@Display Name` text during the storage→markdown conversion, permanently losing the user identity. This made round-trips through `confluence_get_page` → `confluence_update_page` destructive for any page with mentions.

**Fix:** Encode mentions as namespaced pseudo-links in markdown:

```md
[@John Smith](confluence-user:accountId/5a1234abcd)
[@Jane Doe](confluence-user:userKey/jdoe)
```

On write, these are reconstructed back to Confluence storage XML before md2conf processes the element tree.

## Read path changes (`preprocessing/base.py`)

- `_create_user_link_tag()` — new shared helper for creating pseudo-link tags (DRY, used 6 places)
- `CONFLUENCE_USER_SCHEME` — shared constant between read and write paths
- `_replace_user_mention()` — emits pseudo-link instead of plain text
- `_replace_user_mention_by_userkey()` — new method for Server/DC `ri:userkey` mentions
- `_process_user_mentions_in_soup()` — extended to detect `ri:userkey` (was account-id only)
- `_process_user_profile_macros_in_soup()` — same pseudo-link treatment for profile macros

## Write path changes (`preprocessing/confluence.py`)

- `_reconstruct_mentions()` — walks lxml element tree for `<a href="confluence-user:...">` nodes, replaces with `<ac:link><ri:user .../></ac:link>` using proper lxml QName/namespace handling
- Called between `elements_from_string()` and `converter.visit()` to intercept before md2conf's link transformer

## Graceful degradation

- If an agent strips the link, `@John Smith` remains as readable text
- Plain `@Name` without a pseudo-link passes through as literal text on write (no false positives)
- Normal markdown links are unaffected

## Test plan

- [x] Cloud account-id mention → pseudo-link in markdown
- [x] Server/DC userkey mention → pseudo-link in markdown
- [x] Profile macro (account-id + userkey) → pseudo-link in markdown
- [x] Write: accountId pseudo-link → `ri:account-id` storage XML
- [x] Write: userKey pseudo-link → `ri:userkey` storage XML
- [x] Full round-trip: storage → markdown → storage preserves identity
- [x] Plain `@Name` NOT converted to mention on write
- [x] Bold-wrapped mentions round-trip correctly
- [x] Normal links unaffected by reconstruction
- [x] Full suite: 2956 passed, pre-commit clean

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)