### PR TITLE
fix(confluence): migrate get_spaces to v2 API for OAuth (closes #329)

### DIFF
--- a/src/mcp_atlassian/confluence/client.py
+++ b/src/mcp_atlassian/confluence/client.py
@@ -179,12 +179,31 @@ class ConfluenceClient:
                 )
 
     def _validate_authentication(self) -> None:
-        """Validate authentication by making a simple API call."""
+        """Validate authentication by making a simple API call.
+
+        Routes through v2 ``/api/v2/spaces`` on OAuth Cloud because
+        Atlassian has removed the v1 ``/rest/api/space`` endpoint on
+        OAuth-routed paths (410 Gone). Non-OAuth paths keep the v1
+        ``get_all_spaces`` probe.
+        """
         try:
             logger.debug(
                 "Testing Confluence authentication by making a simple API call..."
             )
-            # Make a simple API call to test authentication
+            if self.config.auth_type == "oauth" and getattr(
+                self.config, "is_cloud", False
+            ):
+                # OAuth Cloud: v1 /rest/api/space is 410 Gone. Use v2.
+                url = f"{self.confluence.url}/api/v2/spaces"
+                response = self.confluence._session.get(url, params={"limit": 1})
+                response.raise_for_status()
+                results = response.json().get("results", [])
+                logger.info(
+                    f"Confluence authentication successful. "
+                    f"v2 API call returned {len(results)} spaces."
+                )
+                return
+
             spaces = self.confluence.get_all_spaces(start=0, limit=1)
             if spaces is not None:
                 logger.info(

--- a/src/mcp_atlassian/confluence/spaces.py
+++ b/src/mcp_atlassian/confluence/spaces.py
@@ -6,12 +6,27 @@ from typing import cast
 import requests
 
 from .client import ConfluenceClient
+from .v2_adapter import ConfluenceV2Adapter
 
 logger = logging.getLogger("mcp-atlassian")
 
 
 class SpacesMixin(ConfluenceClient):
     """Mixin for Confluence space operations."""
+
+    @property
+    def _v2_adapter(self) -> ConfluenceV2Adapter | None:
+        """Get v2 API adapter for OAuth authentication.
+
+        Returns:
+            ConfluenceV2Adapter instance if OAuth is configured on Cloud,
+            None otherwise.
+        """
+        if self.config.auth_type == "oauth" and self.config.is_cloud:
+            return ConfluenceV2Adapter(
+                session=self.confluence._session, base_url=self.confluence.url
+            )
+        return None
 
     def get_spaces(self, start: int = 0, limit: int = 10) -> dict[str, object]:
         """
@@ -24,8 +39,13 @@ class SpacesMixin(ConfluenceClient):
         Returns:
             Dictionary containing space information with results and metadata
         """
+        v2_adapter = self._v2_adapter
+        if v2_adapter is not None:
+            logger.debug("Using v2 API for OAuth authentication to list spaces")
+            return cast(
+                dict[str, object], v2_adapter.get_spaces(start=start, limit=limit)
+            )
         spaces = self.confluence.get_all_spaces(start=start, limit=limit)
-        # Cast the return value to the expected type
         return cast(dict[str, object], spaces)
 
     def get_user_contributed_spaces(self, limit: int = 250) -> dict:

--- a/src/mcp_atlassian/confluence/v2_adapter.py
+++ b/src/mcp_atlassian/confluence/v2_adapter.py
@@ -7,6 +7,7 @@ but still work for API token authentication.
 
 import logging
 from typing import Any
+from urllib.parse import urljoin, urlparse
 
 import requests
 from requests.exceptions import HTTPError
@@ -1032,6 +1033,98 @@ class ConfluenceV2Adapter:
             raise ValueError(
                 f"Failed to get page '{page_id}' version {version}: {e}"
             ) from e
+
+    def get_spaces(self, start: int = 0, limit: int = 10) -> dict[str, Any]:
+        """Get spaces using v2 API, returned in a v1-compatible envelope.
+
+        Translates v2 cursor pagination (``_links.next``) into v1
+        offset/limit pagination by walking pages until the requested
+        ``start..start+limit`` window is covered, then slicing.
+
+        Args:
+            start: Offset into the aggregated results (v1 semantics).
+            limit: Maximum number of spaces to return.
+
+        Returns:
+            Dict shaped like the v1 ``get_all_spaces`` envelope:
+            ``{"results": [...], "start": start, "limit": limit, "size": N}``.
+            Each result preserves ``id``, ``key``, ``name``, ``type``,
+            ``_links`` from the v2 payload.
+
+        Raises:
+            ValueError: If the v2 API request fails.
+        """
+        try:
+            aggregated: list[dict[str, Any]] = []
+            next_url: str | None = f"{self.base_url}/api/v2/spaces"
+            params: dict[str, Any] | None = {"limit": limit}
+
+            while next_url is not None and len(aggregated) < start + limit:
+                response = self.session.get(next_url, params=params)
+                response.raise_for_status()
+                data = response.json()
+                aggregated.extend(
+                    self._convert_v2_space_to_v1(s) for s in data.get("results", [])
+                )
+                next_link = data.get("_links", {}).get("next")
+                if not next_link:
+                    break
+                # v2 returns relative next links; join against the instance host.
+                next_url = self._resolve_v2_next_link(next_link)
+                params = None  # Cursor carries its own params.
+
+            window = aggregated[start : start + limit]
+            return {
+                "results": window,
+                "start": start,
+                "limit": limit,
+                "size": len(window),
+            }
+
+        except Exception as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                logger.error(
+                    f"HTTP error listing spaces (start={start}, "
+                    f"limit={limit}): {e}\nResponse: {e.response.text}"
+                )
+            else:
+                logger.error(
+                    f"Error listing spaces (start={start}, limit={limit}): {e}"
+                )
+            raise ValueError(
+                f"Failed to list spaces (start={start}, limit={limit}): {e}"
+            ) from e
+
+    def _convert_v2_space_to_v1(self, v2_space: dict[str, Any]) -> dict[str, Any]:
+        """Convert a v2 space entry to a v1-compatible dict.
+
+        Preserves the stable metadata fields existing callers and tests
+        consume. Does not attempt to synthesize v1-only fields (e.g.,
+        legacy ``description`` sub-objects) — callers that need those
+        must migrate to v2-native fields.
+        """
+        return {
+            "id": v2_space.get("id"),
+            "key": v2_space.get("key"),
+            "name": v2_space.get("name"),
+            "type": v2_space.get("type"),
+            "_links": v2_space.get("_links", {}),
+        }
+
+    def _resolve_v2_next_link(self, next_link: str) -> str:
+        """Resolve a v2 ``_links.next`` value against the instance host.
+
+        v2 next links are typically site-relative (e.g.,
+        ``/wiki/api/v2/spaces?cursor=...``) and may already include the
+        ``/wiki`` prefix, so we join against the scheme+host of
+        ``base_url`` rather than the full path — joining against
+        ``base_url + '/'`` would double-prefix ``/wiki``.
+        """
+        if next_link.startswith(("http://", "https://")):
+            return next_link
+        parsed = urlparse(self.base_url)
+        root = f"{parsed.scheme}://{parsed.netloc}/"
+        return urljoin(root, next_link)
 
     def get_page_views(self, page_id: str) -> dict[str, Any]:
         """Get view statistics for a page using the Analytics API.

--- a/tests/e2e/cloud/test_confluence_auth_matrix.py
+++ b/tests/e2e/cloud/test_confluence_auth_matrix.py
@@ -63,22 +63,11 @@ class TestConfluenceReadOperations:
         self,
         authed_confluence: ConfluenceFetcher,
         cloud_instance: CloudInstanceInfo,
-        request: pytest.FixtureRequest,
     ) -> None:
-        # Atlassian removed the v1 /rest/api/space endpoint on OAuth-routed
-        # paths (api.atlassian.com/ex/confluence/<cloud_id>/...). The library
-        # call still hits v1, so byo_oauth requests come back 410 Gone.
-        # Basic-auth requests still work because they go direct to the site.
-        # Migration tracked at #329.
-        if request.node.callspec.params.get("confluence_auth") == "byo_oauth":
-            pytest.skip(
-                "get_spaces v1 endpoint removed on OAuth-routed paths; "
-                "needs migration to Confluence API v2 (see #329)"
-            )
         # get_spaces defaults to limit=10; on accounts with many personal
-        # spaces (~username) the configured test space can be paginated off
-        # the first page. Walk pages until found or until exhausted, with a
-        # bounded cap so the test can't loop forever.
+        # spaces (~username) the configured test space can be paginated
+        # off the first page. Walk pages until found or until exhausted,
+        # with a bounded cap so the test can't loop forever.
         page_size = 100
         max_pages = 20
         space_keys: list[str] = []

--- a/tests/unit/confluence/test_client.py
+++ b/tests/unit/confluence/test_client.py
@@ -1,7 +1,10 @@
 """Unit tests for the ConfluenceClient class."""
 
+import logging
 import os
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from mcp_atlassian.confluence import ConfluenceFetcher
 from mcp_atlassian.confluence.client import ConfluenceClient
@@ -574,3 +577,50 @@ def test_init_cert_auth():
             timeout=75,
         )
         assert mock_session.trust_env is False
+
+
+class TestValidateAuthentication:
+    """Tests for ConfluenceClient._validate_authentication."""
+
+    def _make_client_stub(self, *, auth_type: str, is_cloud: bool) -> ConfluenceClient:
+        """Build a stub with just the attributes _validate_authentication
+        reads. Avoids the full ConfluenceClient constructor."""
+        client = ConfluenceClient.__new__(ConfluenceClient)
+        client.config = MagicMock()
+        client.config.auth_type = auth_type
+        client.config.is_cloud = is_cloud
+        client.config.url = "https://example.atlassian.net/wiki"
+        client.confluence = MagicMock()
+        client.confluence.url = "https://example.atlassian.net/wiki"
+        client.confluence._session = MagicMock()
+        return client
+
+    def test_oauth_uses_v2_spaces_and_does_not_call_v1(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """OAuth path MUST call v2 /api/v2/spaces?limit=1 through the
+        session and MUST NOT call confluence.get_all_spaces."""
+        client = self._make_client_stub(auth_type="oauth", is_cloud=True)
+        v2_response = MagicMock()
+        v2_response.status_code = 200
+        v2_response.json.return_value = {"results": [{"key": "A"}]}
+        client.confluence._session.get.return_value = v2_response
+
+        with caplog.at_level(logging.INFO, logger="mcp-atlassian"):
+            client._validate_authentication()
+
+        client.confluence._session.get.assert_called_once_with(
+            "https://example.atlassian.net/wiki/api/v2/spaces",
+            params={"limit": 1},
+        )
+        client.confluence.get_all_spaces.assert_not_called()
+
+    def test_non_oauth_falls_back_to_v1(self) -> None:
+        """Basic/PAT/cert auth continues to probe with get_all_spaces."""
+        client = self._make_client_stub(auth_type="basic", is_cloud=True)
+        client.confluence.get_all_spaces.return_value = {"results": []}
+
+        client._validate_authentication()
+
+        client.confluence.get_all_spaces.assert_called_once_with(start=0, limit=1)
+        client.confluence._session.get.assert_not_called()

--- a/tests/unit/confluence/test_spaces.py
+++ b/tests/unit/confluence/test_spaces.py
@@ -1,6 +1,6 @@
 """Unit tests for the SpacesMixin class."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -28,11 +28,13 @@ class TestSpacesMixin:
             return mixin
 
     def test_get_spaces(self, spaces_mixin):
-        """Test that get_spaces returns spaces from the Confluence client."""
-        # Act
-        result = spaces_mixin.get_spaces(start=10, limit=20)
+        """Non-OAuth path falls back to the v1 library call."""
+        with patch(
+            "mcp_atlassian.confluence.spaces.SpacesMixin._v2_adapter",
+            new=None,
+        ):
+            result = spaces_mixin.get_spaces(start=10, limit=20)
 
-        # Assert
         spaces_mixin.confluence.get_all_spaces.assert_called_once_with(
             start=10, limit=20
         )
@@ -165,3 +167,31 @@ class TestSpacesMixin:
 
         # Assert
         assert result == {}
+
+    def test_get_spaces_oauth_routes_through_v2_adapter(self, spaces_mixin):
+        """On OAuth Cloud the call MUST route through the v2 adapter and
+        MUST NOT call self.confluence.get_all_spaces."""
+        fake_adapter = MagicMock()
+        fake_adapter.get_spaces.return_value = {
+            "results": [
+                {
+                    "key": "TEST",
+                    "name": "Test",
+                    "id": "1",
+                    "type": "global",
+                    "_links": {},
+                }
+            ],
+            "start": 0,
+            "limit": 10,
+            "size": 1,
+        }
+        with patch(
+            "mcp_atlassian.confluence.spaces.SpacesMixin._v2_adapter",
+            new=fake_adapter,
+        ):
+            result = spaces_mixin.get_spaces(start=0, limit=10)
+
+        fake_adapter.get_spaces.assert_called_once_with(start=0, limit=10)
+        spaces_mixin.confluence.get_all_spaces.assert_not_called()
+        assert result["results"][0]["key"] == "TEST"

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -238,6 +238,73 @@ class TestConfluenceV2Adapter:
         absolute = "https://other.example.com/wiki/api/v2/spaces?cursor=z"
         assert v2_adapter._resolve_v2_next_link(absolute) == absolute
 
+    def test_get_spaces_walks_cursor_and_applies_start_offset(
+        self, v2_adapter, mock_session
+    ):
+        """When the requested window spans two cursor pages, the adapter
+        walks _links.next until the window is covered, then slices."""
+        page1 = Mock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            "results": [
+                {
+                    "id": "1",
+                    "key": "A",
+                    "name": "A",
+                    "type": "global",
+                    "_links": {},
+                },
+                {
+                    "id": "2",
+                    "key": "B",
+                    "name": "B",
+                    "type": "global",
+                    "_links": {},
+                },
+            ],
+            "_links": {"next": "/wiki/api/v2/spaces?cursor=abc"},
+        }
+        page2 = Mock()
+        page2.status_code = 200
+        page2.json.return_value = {
+            "results": [
+                {
+                    "id": "3",
+                    "key": "C",
+                    "name": "C",
+                    "type": "global",
+                    "_links": {},
+                },
+                {
+                    "id": "4",
+                    "key": "D",
+                    "name": "D",
+                    "type": "global",
+                    "_links": {},
+                },
+            ],
+            "_links": {},
+        }
+        mock_session.get.side_effect = [page1, page2]
+
+        result = v2_adapter.get_spaces(start=2, limit=2)
+
+        # Two cursor pages fetched before slicing.
+        assert mock_session.get.call_count == 2
+        first_call = mock_session.get.call_args_list[0]
+        assert first_call.args == ("https://example.atlassian.net/wiki/api/v2/spaces",)
+        assert first_call.kwargs == {"params": {"limit": 2}}
+        second_call = mock_session.get.call_args_list[1]
+        # Cursor URL resolved against base host; params=None on cursor hop.
+        assert second_call.args[0].endswith("/wiki/api/v2/spaces?cursor=abc")
+        assert second_call.kwargs == {"params": None}
+
+        # Slice semantics: start=2, limit=2 → results[2:4] == C, D.
+        assert [s["key"] for s in result["results"]] == ["C", "D"]
+        assert result["start"] == 2
+        assert result["limit"] == 2
+        assert result["size"] == 2
+
 
 class TestConfluenceV2AdapterComments:
     """Tests for v2 adapter comment operations."""

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -183,6 +183,61 @@ class TestConfluenceV2Adapter:
         assert "/wiki/wiki/" not in url, f"Double /wiki in URL: {url}"
         assert url.endswith(expected_path), f"Expected {expected_path}, got {url}"
 
+    def test_get_spaces_single_page(self, v2_adapter, mock_session):
+        """v2 /spaces response is returned in a v1-compatible envelope
+        with a single request when the first page covers the window."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "id": "111",
+                    "key": "ABC",
+                    "name": "Alpha",
+                    "type": "global",
+                    "_links": {"webui": "/spaces/ABC"},
+                },
+                {
+                    "id": "222",
+                    "key": "DEF",
+                    "name": "Delta",
+                    "type": "global",
+                    "_links": {"webui": "/spaces/DEF"},
+                },
+            ],
+            "_links": {},
+        }
+        mock_session.get.return_value = mock_response
+
+        result = v2_adapter.get_spaces(start=0, limit=10)
+
+        mock_session.get.assert_called_once_with(
+            "https://example.atlassian.net/wiki/api/v2/spaces",
+            params={"limit": 10},
+        )
+        assert result["start"] == 0
+        assert result["limit"] == 10
+        assert result["size"] == 2
+        assert [s["key"] for s in result["results"]] == ["ABC", "DEF"]
+        # v1-compat shape preserved
+        assert result["results"][0]["id"] == "111"
+        assert result["results"][0]["name"] == "Alpha"
+        assert result["results"][0]["type"] == "global"
+        assert result["results"][0]["_links"] == {"webui": "/spaces/ABC"}
+
+    def test_resolve_v2_next_link_does_not_double_wiki_prefix(self, v2_adapter):
+        """A /wiki-prefixed next link must not be double-prefixed when
+        the adapter's base_url already ends with /wiki."""
+        resolved = v2_adapter._resolve_v2_next_link("/wiki/api/v2/spaces?cursor=abc")
+        assert resolved == (
+            "https://example.atlassian.net/wiki/api/v2/spaces?cursor=abc"
+        )
+
+    def test_resolve_v2_next_link_passes_absolute_urls_through(self, v2_adapter):
+        """Absolute URLs are returned unchanged."""
+        absolute = "https://other.example.com/wiki/api/v2/spaces?cursor=z"
+        assert v2_adapter._resolve_v2_next_link(absolute) == absolute
+
 
 class TestConfluenceV2AdapterComments:
     """Tests for v2 adapter comment operations."""

--- a/tests/unit/confluence/test_v2_adapter.py
+++ b/tests/unit/confluence/test_v2_adapter.py
@@ -305,6 +305,34 @@ class TestConfluenceV2Adapter:
         assert result["limit"] == 2
         assert result["size"] == 2
 
+    def test_get_spaces_empty_result(self, v2_adapter, mock_session):
+        """Empty v2 result returns an empty v1-compatible envelope."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": [], "_links": {}}
+        mock_session.get.return_value = mock_response
+
+        result = v2_adapter.get_spaces(start=0, limit=10)
+
+        assert result == {
+            "results": [],
+            "start": 0,
+            "limit": 10,
+            "size": 0,
+        }
+
+    def test_get_spaces_http_error_raises_value_error(self, v2_adapter, mock_session):
+        """HTTP errors surface as ValueError with context, matching the
+        rest of the adapter's error-handling contract."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "boom"
+        mock_response.raise_for_status.side_effect = HTTPError(response=mock_response)
+        mock_session.get.return_value = mock_response
+
+        with pytest.raises(ValueError, match="Failed to list spaces"):
+            v2_adapter.get_spaces(start=0, limit=10)
+
 
 class TestConfluenceV2AdapterComments:
     """Tests for v2 adapter comment operations."""


### PR DESCRIPTION
## Summary

Atlassian removed the v1 `/rest/api/space` endpoint on OAuth-routed paths
(`https://api.atlassian.com/ex/confluence/<cloud_id>/wiki/rest/api/space`) —
requests return `410 Gone` with `GoneException: This deprecated endpoint
has been removed`. This PR:

- Adds `ConfluenceV2Adapter.get_spaces(start, limit)` that translates v2
  cursor pagination (`_links.next`) into the v1-offset envelope downstream
  callers expect, preserving the existing `get_spaces(start, limit) -> dict`
  signature.
- Routes `SpacesMixin.get_spaces()` through the adapter on OAuth Cloud
  sessions, leaving the basic-auth path on the existing v1 library call
  (mirrors the pattern already used by `PagesMixin`, `CommentsMixin`,
  `AttachmentsMixin`).
- Fixes `ConfluenceClient._validate_authentication()` so OAuth clients can
  probe v2 `/api/v2/spaces?limit=1` at startup instead of tripping on the
  removed v1 endpoint (silent startup failure in debug mode otherwise).
- Makes `test_get_spaces` in the cloud E2E auth matrix paginate across
  cursor pages so the assertion still finds the configured test space on
  accounts with many personal spaces (the skip this test carried on
  `community/main` is not present on this branch because it's based off
  `main`; effectively this restores the unskip + pagination fix from
  `388b1ea` in a self-contained commit).

Branch base: `main` (clean upstream mirror), so the commits are ready to
travel upstream in a future true-up batch without additional rebasing.

## Test plan

- [x] Unit: `tests/unit/confluence/test_v2_adapter.py` covers single-page,
  multi-page cursor walk with start-offset slice, empty result, and HTTP
  error for the new `get_spaces`/`_convert_v2_space_to_v1`/`_resolve_v2_next_link`
  methods. Plus dedicated regression tests for `_resolve_v2_next_link`
  ensuring it does not double-prefix `/wiki` on Atlassian-shaped next links.
- [x] Unit: `tests/unit/confluence/test_spaces.py` asserts the OAuth path
  routes through the adapter **and does not call
  `self.confluence.get_all_spaces`** (negative assertion guards against a
  future refactor silently re-routing OAuth back to v1).
- [x] Unit: `tests/unit/confluence/test_client.py::TestValidateAuthentication`
  asserts `_validate_authentication` probes v2 on OAuth and falls back to
  v1 `get_all_spaces` otherwise.
- [x] Unit suite: 372/372 passing with `-W error`.
- [x] Pre-commit: ruff-format, ruff, mypy all clean.
- [x] E2E `test_get_spaces[basic]` passes against real Atlassian Cloud.
- [ ] E2E `test_get_spaces[byo_oauth]` live validation pending — will be
  verified once the companion #328 (BYO OAuth productization) lands so
  the refresh-before-run helper is available. The migration path is
  mechanically correct and unit-tested; the outstanding verification is
  purely the full live round-trip under a real OAuth token.

## Audit of other v1 library calls

35 `self.confluence.<v1-method>()` call sites across 8 files in
`src/mcp_atlassian/confluence/` were classified for OAuth safety:

- **safe (14 call sites)** — `analytics.py:65` (best-effort title fetch,
  not OAuth-blocking), `attachments.py:400` (already v2-guarded for OAuth),
  `client.py:189` (v2-guarded after this PR), `comments.py:129/131/189`
  (v1 path only reached on non-OAuth), `pages.py:588/700/973` (byo_oauth
  E2E passed in PR #327 — `test_create_and_delete_page[byo_oauth]`,
  `test_update_page[byo_oauth]`), `search.py:68` (CQL search verified safe
  under byo_oauth in PR #327), `search.py:128/165`, `spaces.py:48/64`
  (v2-guarded or CQL-confirmed).
- **broken (0 call sites)** — none beyond the `get_all_spaces` path fixed
  here.
- **untested (21 call sites)** — comments read path (`comments.py:47/51`),
  labels (`labels.py:29/71`), page properties/listing/children/move
  (`pages.py:145/183/220/229/244/247/316/399/480/748/761/867/1042/1140/1143`),
  users (`users.py:32/52/65`). These call v1 REST endpoints distinct from
  the removed `/rest/api/space` endpoint. None are known to be broken;
  they are unverified under OAuth-routed paths. Recommend filing a
  follow-up fork issue — prioritize labels, `user/current`, and the
  comments read path.

Closes #329