### PR TITLE
feat(auth): productize BYO OAuth E2E test workflow (closes #328)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -275,27 +275,30 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # Required for the byo_oauth-parametrized tests in tests/e2e/cloud/, which
 # run against a real Atlassian Cloud instance under `--cloud-e2e`.
 #
-# Refresh path (recommended): wrap pytest in scripts/oauth_refresh.py to mint
-# a fresh access_token from a stored refresh_token before each run. See
-# scripts/README.md for the full workflow.
+# Recommended path: scripts/oauth_refresh.py with `--store 1password` reads
+# credentials from your 1Password vault, refreshes the access token,
+# persists the rotated refresh token back to the same vault, and exec's
+# pytest. See scripts/README.md for the full workflow.
+
+# --- Option 1: 1Password store (recommended for maintainers) ---
+# Replace the UUIDs with your own (op vault list, op item get <name> --format json).
+#CLOUD_E2E_OAUTH_BACKEND=1password
+#ATLASSIAN_OAUTH_OP_VAULT=<your-vault-uuid>
+#ATLASSIAN_OAUTH_OP_ITEM=<your-item-uuid>
 #
-# Direct literal values (no 1Password / no keyring needed):
-#CLOUD_E2E_OAUTH_ACCESS_TOKEN=
-#CLOUD_E2E_OAUTH_CLOUD_ID=
-#
-# For scripts/oauth_refresh.py to mint a new access_token:
+# Required for stale-token auto-recovery (browser authorize flow):
+#ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work read:jira-user offline_access ...
+#ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback
+
+# --- Option 2: literal env vars (CI / no 1Password) ---
+# For scripts/oauth_refresh.py with `--store env` (the default):
 #ATLASSIAN_OAUTH_CLIENT_ID=
 #ATLASSIAN_OAUTH_CLIENT_SECRET=
 #CLOUD_E2E_OAUTH_REFRESH_TOKEN=
 #CLOUD_E2E_OAUTH_CLOUD_ID=
-#
-# Alternative: 1Password users invoke `op run --env-file=.env -- ...` so
-# `op://` references in this file are substituted before the test command
-# runs. Use UUIDs in the op:// path — vault names with parens or em-dashes
-# break the parser ("invalid character in secret reference"). Get UUIDs
-# from `op vault list` and `op item get <name> --format json`.
-#
-#ATLASSIAN_OAUTH_CLIENT_ID=op://<vault-uuid>/<item-uuid>/Atlassian Credentials/client_id
-#ATLASSIAN_OAUTH_CLIENT_SECRET=op://<vault-uuid>/<item-uuid>/Atlassian Credentials/client_secret
-#CLOUD_E2E_OAUTH_REFRESH_TOKEN=op://<vault-uuid>/<item-uuid>/OAuth Credentials/refresh_token
-#CLOUD_E2E_OAUTH_CLOUD_ID=op://<vault-uuid>/<item-uuid>/OAuth Credentials/cloud_id
+
+# --- Option 3: direct access token (skip refresh entirely) ---
+# If pytest is invoked with these set, the byo_oauth fixture uses them as-is.
+# Useful when an external process has already minted a fresh access token.
+#CLOUD_E2E_OAUTH_ACCESS_TOKEN=
+#CLOUD_E2E_OAUTH_CLOUD_ID=

--- a/.env.example
+++ b/.env.example
@@ -268,3 +268,34 @@ MCP_VERY_VERBOSE=true   # Enables DEBUG level logging (equivalent to 'mcp-atlass
 # Format: name=value pairs separated by "; " (exactly as a Cookie header).
 #JIRA_COOKIE=JSESSIONID=abc123; other_cookie=xyz
 #CONFLUENCE_COOKIE=JSESSIONID=abc123; other_cookie=xyz
+
+# =============================================
+# BYO OAUTH CLOUD E2E TEST CREDENTIALS (Contributors only)
+# =============================================
+# Required for the byo_oauth-parametrized tests in tests/e2e/cloud/, which
+# run against a real Atlassian Cloud instance under `--cloud-e2e`.
+#
+# Refresh path (recommended): wrap pytest in scripts/oauth_refresh.py to mint
+# a fresh access_token from a stored refresh_token before each run. See
+# scripts/README.md for the full workflow.
+#
+# Direct literal values (no 1Password / no keyring needed):
+#CLOUD_E2E_OAUTH_ACCESS_TOKEN=
+#CLOUD_E2E_OAUTH_CLOUD_ID=
+#
+# For scripts/oauth_refresh.py to mint a new access_token:
+#ATLASSIAN_OAUTH_CLIENT_ID=
+#ATLASSIAN_OAUTH_CLIENT_SECRET=
+#CLOUD_E2E_OAUTH_REFRESH_TOKEN=
+#CLOUD_E2E_OAUTH_CLOUD_ID=
+#
+# Alternative: 1Password users invoke `op run --env-file=.env -- ...` so
+# `op://` references in this file are substituted before the test command
+# runs. Use UUIDs in the op:// path — vault names with parens or em-dashes
+# break the parser ("invalid character in secret reference"). Get UUIDs
+# from `op vault list` and `op item get <name> --format json`.
+#
+#ATLASSIAN_OAUTH_CLIENT_ID=op://<vault-uuid>/<item-uuid>/Atlassian Credentials/client_id
+#ATLASSIAN_OAUTH_CLIENT_SECRET=op://<vault-uuid>/<item-uuid>/Atlassian Credentials/client_secret
+#CLOUD_E2E_OAUTH_REFRESH_TOKEN=op://<vault-uuid>/<item-uuid>/OAuth Credentials/refresh_token
+#CLOUD_E2E_OAUTH_CLOUD_ID=op://<vault-uuid>/<item-uuid>/OAuth Credentials/cloud_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,10 +113,15 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "tests/**/*.py" = ["S", "ANN", "B017"]
 "tests/fixtures/*.py" = ["E501"]
 "src/mcp_atlassian/server.py" = ["E501"]
-# CLI helpers invoke external tools (op, browser callback, exec)
-# intentionally and on user-controlled input; the S-rules don't add
-# signal here.
-"scripts/**/*.py" = ["S"]
+# CLI helpers invoke external tools (op, browser callback, exec) intentionally
+# and on user-controlled input. Narrow the suppressions to the specific
+# subprocess/exec rules that fire — keep all other Bandit-family checks
+# (input validation, hash strength, SSL config, etc.) active.
+#   S101 — assertion statements (used in test-style helpers under scripts/)
+#   S603 — subprocess call: untrusted input (user passes argv flags)
+#   S606 — Starting a process without a shell (os.execvpe is the point)
+#   S607 — Starting a process with a partial executable path (`op` via PATH)
+"scripts/**/*.py" = ["S101", "S603", "S606", "S607"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,10 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "tests/**/*.py" = ["S", "ANN", "B017"]
 "tests/fixtures/*.py" = ["E501"]
 "src/mcp_atlassian/server.py" = ["E501"]
+# CLI helpers invoke external tools (op, browser callback, exec)
+# intentionally and on user-controlled input; the S-rules don't add
+# signal here.
+"scripts/**/*.py" = ["S"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,12 +64,39 @@ Run the BYO OAuth E2E tests with a fresh token:
 ```bash
 op run --env-file=.env -- \
     uv run python scripts/oauth_refresh.py \
+        --write-cmd 'op item edit h4uocvrp4sowktnke4zwu27axq \
+            "OAuth Credentials.access_token=$ATLASSIAN_OAUTH_ACCESS_TOKEN" \
+            "OAuth Credentials.refresh_token=$ATLASSIAN_OAUTH_REFRESH_TOKEN"' \
         --exec uv run pytest tests/e2e/cloud/ -k byo_oauth --cloud-e2e -W error
 ```
 
 The `op run` wrapper substitutes `op://...` references in `.env` to literal
 values before this script sees them. Without 1Password, populate the
 `CLOUD_E2E_OAUTH_*` and `ATLASSIAN_OAUTH_*` vars directly.
+
+### `--write-cmd` and Atlassian's refresh-token rotation
+
+Atlassian Cloud rotates the refresh token on every refresh — the old token is
+invalidated as soon as a new one is issued. If the rotated token isn't
+persisted somewhere, the next run sees a stale refresh token and fails with
+`401 Unauthorized` / `403 Forbidden` from the token endpoint.
+
+Default JSON-stdout mode preserves the rotated token (it's included in the
+JSON payload — pipe it to your secrets store). For `--exec` mode, use
+`--write-cmd` to update storage between refresh and exec; `--exec` cannot
+emit the token itself because it replaces the process.
+
+The write command runs:
+
+- After a successful refresh and before `--exec`.
+- With `ATLASSIAN_OAUTH_ACCESS_TOKEN`, `ATLASSIAN_OAUTH_REFRESH_TOKEN`, `ATLASSIAN_OAUTH_CLOUD_ID`, and `ATLASSIAN_OAUTH_EXPIRES_AT` in the environment.
+- With `stdin` redirected to `/dev/null` (so `op item edit` does not try to parse the parent's stdin as a JSON template — see the [op subprocess gotcha](#op-item-edit-scripting-gotchas) below).
+- Through `/bin/sh -c` (`shell=True`), so shell features like `$VAR` expansion and quoting work as expected.
+
+If the write command exits non-zero, `oauth_refresh.py` exits with the same
+code and does **not** run `--exec`. This is deliberate: if storage didn't
+update with the rotated refresh token, running the test would just consume
+another refresh and leave you in the same broken state.
 
 ---
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,109 +1,103 @@
 # Scripts
 
-Helper scripts for OAuth setup and tooling.
+Helper scripts for OAuth setup and BYO OAuth E2E test workflows.
 
-## `oauth_authorize.py` — interactive OAuth authorization flow
+## TL;DR for maintainers running the cloud E2E suite
 
-Runs Atlassian's OAuth 2.0 (3LO) authorization code flow: opens a browser to
-the authorization URL, hosts a localhost callback server, exchanges the
-authorization code for tokens, and (by default) saves the tokens to the OS
-keyring with a JSON backup at `~/.mcp-atlassian/oauth-<client_id>.json`.
+Set up your `.env` once with credentials in your secret store of choice, then:
+
+```bash
+op run --env-file=.env -- \
+    uv run python scripts/oauth_refresh.py \
+        --store 1password \
+        --exec uv run pytest tests/e2e/cloud/ -k byo_oauth --cloud-e2e -W error
+```
+
+That's it. The helper reads credentials from the configured store, refreshes
+the access token, persists the rotated refresh token back to the same store,
+and exec's pytest with the fresh credentials in its environment. No shell
+incantations to memorize, no manual cleanup after rotation, no token files
+to delete from `~/.mcp-atlassian/`.
+
+If the stored refresh token has gone stale (Atlassian invalidated it because
+something else consumed it), the helper falls back to the interactive
+authorize flow — open the URL it prints, click consent, and the new tokens
+are persisted to the store before pytest runs.
+
+---
+
+## Per-script reference
+
+### `oauth_authorize.py` — initial token mint
+
+Bootstrap path. Run this **once** when registering a new Atlassian OAuth
+app to mint the initial `access_token` / `refresh_token` / `cloud_id`. After
+that, `oauth_refresh.py` handles everything.
 
 ```bash
 uv run python scripts/oauth_authorize.py \
     --client-id YOUR_CLIENT_ID \
     --client-secret YOUR_CLIENT_SECRET \
     --redirect-uri http://localhost:8080/callback \
-    --scope "read:jira-work offline_access ..."
+    --scope "read:jira-work offline_access ..." \
+    --no-persist
 ```
 
-### `--no-persist` mode (BYO secret store)
+`--no-persist` suppresses on-disk and keyring writes; the JSON token block
+goes to stdout for the caller to capture into a secret store. Without
+`--no-persist`, tokens are saved to `~/.mcp-atlassian/oauth-<client_id>.json`
+plus the OS keyring (the upstream default — useful for local-only runs but
+not for the BYO secret-store workflow).
 
-Add `--no-persist` to suppress all on-disk and keyring writes. On success the
-script emits a JSON token block to stdout — the caller is responsible for
-storing it (e.g. piping into `op item edit`). Nothing is written to
-`~/.mcp-atlassian/` or the OS keyring.
+### `oauth_refresh.py` — refresh + persist + exec
 
-```bash
-uv run python scripts/oauth_authorize.py \
-    --client-id ... --client-secret ... --redirect-uri ... --scope ... \
-    --no-persist > /tmp/tokens.json
-```
+The maintainer-facing entry point. Reads credentials from a configured
+secret store, refreshes the access token, persists the rotated refresh token,
+and either prints JSON to stdout or execs a child command.
 
-The JSON block has the shape:
+#### `--store` (env | 1password)
 
-```json
-{
-  "access_token": "...",
-  "refresh_token": "...",
-  "expires_at": 1234567890.0,
-  "cloud_id": "..."        // or "base_url" for Server/DC
-}
-```
+Default `env`. Also configurable via the `CLOUD_E2E_OAUTH_BACKEND`
+environment variable.
 
-## `oauth_refresh.py` — refresh access token from stored refresh_token
+- **`env`** — reads literal env vars, no write-back. Suitable for CI runs
+  where the CI system injects credentials per-job, or for one-off runs
+  where the rotated token can be captured from the JSON stdout. If the
+  refresh token has gone stale, the script reports the error and exits
+  non-zero (no automatic re-auth, since there's nowhere to write the new
+  token).
+- **`1password`** — reads + writes via the `op` CLI. The script owns `op`
+  invocations directly with a list argv (no `shell=True`), so the rotated
+  refresh token never passes through a shell string. Required additional
+  flags: `--op-vault VAULT_UUID` and `--op-item-id ITEM_UUID` (or the
+  `ATLASSIAN_OAUTH_OP_VAULT` / `ATLASSIAN_OAUTH_OP_ITEM` env vars). On
+  refresh failure, falls back to the interactive authorize flow and
+  persists the new tokens to the store.
 
-Mints a fresh access token using a long-lived refresh token, without
-persisting anything. Used to wrap pytest invocations of the BYO OAuth E2E
-suite so each run gets a token within Atlassian's ~1-hour expiry window.
+Adding a new backend (Vault, AWS Secrets Manager, GCP Secret Manager, etc.)
+is a matter of adding a class to `_oauth_stores.py` that implements the
+same `read()` / `write()` / `writable()` surface; `oauth_refresh.py` will
+pick it up via the `--store` flag.
 
-Required environment variables:
+#### `--exec CMD ARG...`
 
-- `ATLASSIAN_OAUTH_CLIENT_ID`
-- `ATLASSIAN_OAUTH_CLIENT_SECRET`
-- `CLOUD_E2E_OAUTH_REFRESH_TOKEN`
-- `CLOUD_E2E_OAUTH_CLOUD_ID`
+After a successful refresh + persist, exec the given command with
+`CLOUD_E2E_OAUTH_ACCESS_TOKEN` and `CLOUD_E2E_OAUTH_CLOUD_ID` set in the
+child environment. Designed to wrap pytest invocations of the
+`byo_oauth`-parametrized tests in `tests/e2e/cloud/`, which read those
+two env vars via `CloudInstanceInfo.from_env()`.
 
-Two output modes:
+#### Default mode (no `--exec`)
 
-- **Default (stdout JSON)**: prints `{access_token, refresh_token, cloud_id, expires_at}` to stdout.
-- **`--exec CMD ARG...`**: sets `CLOUD_E2E_OAUTH_ACCESS_TOKEN` and `CLOUD_E2E_OAUTH_CLOUD_ID` in the child environment, then execs the given command.
-
-Run the BYO OAuth E2E tests with a fresh token:
-
-```bash
-op run --env-file=.env -- \
-    uv run python scripts/oauth_refresh.py \
-        --write-cmd 'op item edit h4uocvrp4sowktnke4zwu27axq \
-            "OAuth Credentials.access_token=$ATLASSIAN_OAUTH_ACCESS_TOKEN" \
-            "OAuth Credentials.refresh_token=$ATLASSIAN_OAUTH_REFRESH_TOKEN"' \
-        --exec uv run pytest tests/e2e/cloud/ -k byo_oauth --cloud-e2e -W error
-```
-
-The `op run` wrapper substitutes `op://...` references in `.env` to literal
-values before this script sees them. Without 1Password, populate the
-`CLOUD_E2E_OAUTH_*` and `ATLASSIAN_OAUTH_*` vars directly.
-
-### `--write-cmd` and Atlassian's refresh-token rotation
-
-Atlassian Cloud rotates the refresh token on every refresh — the old token is
-invalidated as soon as a new one is issued. If the rotated token isn't
-persisted somewhere, the next run sees a stale refresh token and fails with
-`401 Unauthorized` / `403 Forbidden` from the token endpoint.
-
-Default JSON-stdout mode preserves the rotated token (it's included in the
-JSON payload — pipe it to your secrets store). For `--exec` mode, use
-`--write-cmd` to update storage between refresh and exec; `--exec` cannot
-emit the token itself because it replaces the process.
-
-The write command runs:
-
-- After a successful refresh and before `--exec`.
-- With `ATLASSIAN_OAUTH_ACCESS_TOKEN`, `ATLASSIAN_OAUTH_REFRESH_TOKEN`, `ATLASSIAN_OAUTH_CLOUD_ID`, and `ATLASSIAN_OAUTH_EXPIRES_AT` in the environment.
-- With `stdin` redirected to `/dev/null` (so `op item edit` does not try to parse the parent's stdin as a JSON template — see the [op subprocess gotcha](#op-item-edit-scripting-gotchas) below).
-- Through `/bin/sh -c` (`shell=True`), so shell features like `$VAR` expansion and quoting work as expected.
-
-If the write command exits non-zero, `oauth_refresh.py` exits with the same
-code and does **not** run `--exec`. This is deliberate: if storage didn't
-update with the rotated refresh token, running the test would just consume
-another refresh and leave you in the same broken state.
+Prints the refreshed `{access_token, refresh_token, cloud_id, expires_at}`
+JSON block to stdout. Useful for piping into a different secrets store, for
+debugging, or when the test runner is invoked separately from a CI step.
 
 ---
 
-## Operational notes (collected from the PR #327 verification)
+## Operational notes
 
-These details were learned the hard way during the FastMCP 3.x port end-to-end
-verification. They apply when registering an Atlassian OAuth app and storing
+These details applied when registering an Atlassian OAuth app and storing
 its credentials in 1Password for use with the scripts above.
 
 ### Atlassian OAuth app configuration
@@ -131,23 +125,43 @@ offline_access
 
 ### 1Password item layout
 
-If storing credentials in 1Password, a two-section login item works well:
+For the `1password` store, the item must have two sections with these
+field labels (label-only — no section prefix in op:// references for read):
 
-- **Atlassian Credentials**: `client_id` (text), `client_secret` (concealed) — set once from the developer console, filled manually.
-- **OAuth Credentials**: `cloud_id` (text), `access_token` (concealed), `refresh_token` (concealed) — empty until the authorize/refresh scripts populate them.
+- **Atlassian Credentials**: `client_id` (text), `client_secret` (concealed)
+- **OAuth Credentials**: `cloud_id` (text), `access_token` (concealed), `refresh_token` (concealed)
 
-For `op://` references in `.env`, **always use UUIDs** (from `op vault list`
-and `op item get <name> --format json`). Display names with parens or
-em-dashes break the parser with `invalid character in secret reference`.
+Use **vault and item UUIDs** (not display names) in your `.env` —
+display names with parens, em-dashes, or other punctuation break the
+`op://` parser with `invalid character in secret reference`. Get UUIDs
+from `op vault list` and `op item get <name> --format json`.
 
-### `op item edit` scripting gotchas
+`.env` template (gitignored — fill in the real UUIDs from your environment):
 
-- When invoking `op item edit` from a subprocess, pass `stdin=subprocess.DEVNULL` (or `< /dev/null` in shell). Otherwise op tries to parse the parent's stdin as a JSON template and fails with `invalid JSON provided`.
-- Section prefix is required for `op item edit` field assignments: `op item edit <id> "OAuth Credentials.access_token=<value>"`.
-- Field labels are unique across sections, so reading via `op://vault/item/<field>` does not need a section prefix.
+```
+CLOUD_E2E_OAUTH_BACKEND=1password
+ATLASSIAN_OAUTH_OP_VAULT=<your-vault-uuid>
+ATLASSIAN_OAUTH_OP_ITEM=<your-item-uuid>
+
+# For automatic re-authorization when the stored refresh token has gone stale,
+# set the same scope and redirect URI you used at initial registration:
+ATLASSIAN_OAUTH_SCOPE=read:jira-work write:jira-work ... offline_access
+ATLASSIAN_OAUTH_REDIRECT_URI=http://localhost:8080/callback
+```
+
+The `1password` store invokes `op` directly via subprocess (not through a
+shell), passes secrets as discrete arg-list elements, and pipes
+`stdin=DEVNULL` into `op item edit` so op does not try to parse the
+parent's stdin as a JSON template.
 
 ### Behavior notes for `oauth_authorize.py`
 
-- In WSL the script can't `webbrowser.open()` (`gio` fails with `Operation not supported`) — the auth URL is logged to stderr, open it manually. The callback server still listens on localhost:8080.
-- The authorization URL has `prompt=consent` hard-coded, so the consent screen appears on every run, even after first approval.
-- Token exchange failures return generic `401 access_denied` regardless of root cause. Most common causes: (a) `client_secret` mismatch (rotated in console without updating storage), (b) redirect URI mismatch, (c) authorization code already consumed (single-use).
+- In WSL the script can't `webbrowser.open()` (`gio` fails with `Operation
+  not supported`) — the auth URL is logged to stderr, open it manually. The
+  callback server still listens on localhost:8080.
+- The authorization URL has `prompt=consent` hard-coded, so the consent
+  screen appears on every run, even after first approval.
+- Token exchange failures return generic `401 access_denied` regardless of
+  root cause. Most common causes: (a) `client_secret` mismatch (rotated in
+  console without updating storage), (b) redirect URI mismatch, (c)
+  authorization code already consumed (single-use).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,126 @@
+# Scripts
+
+Helper scripts for OAuth setup and tooling.
+
+## `oauth_authorize.py` — interactive OAuth authorization flow
+
+Runs Atlassian's OAuth 2.0 (3LO) authorization code flow: opens a browser to
+the authorization URL, hosts a localhost callback server, exchanges the
+authorization code for tokens, and (by default) saves the tokens to the OS
+keyring with a JSON backup at `~/.mcp-atlassian/oauth-<client_id>.json`.
+
+```bash
+uv run python scripts/oauth_authorize.py \
+    --client-id YOUR_CLIENT_ID \
+    --client-secret YOUR_CLIENT_SECRET \
+    --redirect-uri http://localhost:8080/callback \
+    --scope "read:jira-work offline_access ..."
+```
+
+### `--no-persist` mode (BYO secret store)
+
+Add `--no-persist` to suppress all on-disk and keyring writes. On success the
+script emits a JSON token block to stdout — the caller is responsible for
+storing it (e.g. piping into `op item edit`). Nothing is written to
+`~/.mcp-atlassian/` or the OS keyring.
+
+```bash
+uv run python scripts/oauth_authorize.py \
+    --client-id ... --client-secret ... --redirect-uri ... --scope ... \
+    --no-persist > /tmp/tokens.json
+```
+
+The JSON block has the shape:
+
+```json
+{
+  "access_token": "...",
+  "refresh_token": "...",
+  "expires_at": 1234567890.0,
+  "cloud_id": "..."        // or "base_url" for Server/DC
+}
+```
+
+## `oauth_refresh.py` — refresh access token from stored refresh_token
+
+Mints a fresh access token using a long-lived refresh token, without
+persisting anything. Used to wrap pytest invocations of the BYO OAuth E2E
+suite so each run gets a token within Atlassian's ~1-hour expiry window.
+
+Required environment variables:
+
+- `ATLASSIAN_OAUTH_CLIENT_ID`
+- `ATLASSIAN_OAUTH_CLIENT_SECRET`
+- `CLOUD_E2E_OAUTH_REFRESH_TOKEN`
+- `CLOUD_E2E_OAUTH_CLOUD_ID`
+
+Two output modes:
+
+- **Default (stdout JSON)**: prints `{access_token, refresh_token, cloud_id, expires_at}` to stdout.
+- **`--exec CMD ARG...`**: sets `CLOUD_E2E_OAUTH_ACCESS_TOKEN` and `CLOUD_E2E_OAUTH_CLOUD_ID` in the child environment, then execs the given command.
+
+Run the BYO OAuth E2E tests with a fresh token:
+
+```bash
+op run --env-file=.env -- \
+    uv run python scripts/oauth_refresh.py \
+        --exec uv run pytest tests/e2e/cloud/ -k byo_oauth --cloud-e2e -W error
+```
+
+The `op run` wrapper substitutes `op://...` references in `.env` to literal
+values before this script sees them. Without 1Password, populate the
+`CLOUD_E2E_OAUTH_*` and `ATLASSIAN_OAUTH_*` vars directly.
+
+---
+
+## Operational notes (collected from the PR #327 verification)
+
+These details were learned the hard way during the FastMCP 3.x port end-to-end
+verification. They apply when registering an Atlassian OAuth app and storing
+its credentials in 1Password for use with the scripts above.
+
+### Atlassian OAuth app configuration
+
+- Register the redirect URI in the developer console **exactly** as
+  `http://localhost:8080/callback`.
+- The app's **Permissions** page is authoritative for which scopes the OAuth
+  flow can request. Both **classic** and **granular** Confluence scopes must
+  be registered for the v2 REST endpoints this codebase uses to work — the
+  underlying `atlassian-python-api` library still hits some v1 endpoints
+  (`/rest/api/space`, `/rest/api/content/search`) which only honor classic
+  scopes, while v2 endpoints require granular `<verb>:<resource>:confluence`
+  scopes.
+
+Scopes used successfully for the full BYO OAuth E2E matrix:
+
+```
+read:jira-work write:jira-work read:jira-user
+read:page:confluence write:page:confluence delete:page:confluence
+read:space:confluence read:attachment:confluence write:attachment:confluence
+read:comment:confluence write:comment:confluence read:user:confluence
+read:confluence-space.summary read:confluence-content.all
+offline_access
+```
+
+### 1Password item layout
+
+If storing credentials in 1Password, a two-section login item works well:
+
+- **Atlassian Credentials**: `client_id` (text), `client_secret` (concealed) — set once from the developer console, filled manually.
+- **OAuth Credentials**: `cloud_id` (text), `access_token` (concealed), `refresh_token` (concealed) — empty until the authorize/refresh scripts populate them.
+
+For `op://` references in `.env`, **always use UUIDs** (from `op vault list`
+and `op item get <name> --format json`). Display names with parens or
+em-dashes break the parser with `invalid character in secret reference`.
+
+### `op item edit` scripting gotchas
+
+- When invoking `op item edit` from a subprocess, pass `stdin=subprocess.DEVNULL` (or `< /dev/null` in shell). Otherwise op tries to parse the parent's stdin as a JSON template and fails with `invalid JSON provided`.
+- Section prefix is required for `op item edit` field assignments: `op item edit <id> "OAuth Credentials.access_token=<value>"`.
+- Field labels are unique across sections, so reading via `op://vault/item/<field>` does not need a section prefix.
+
+### Behavior notes for `oauth_authorize.py`
+
+- In WSL the script can't `webbrowser.open()` (`gio` fails with `Operation not supported`) — the auth URL is logged to stderr, open it manually. The callback server still listens on localhost:8080.
+- The authorization URL has `prompt=consent` hard-coded, so the consent screen appears on every run, even after first approval.
+- Token exchange failures return generic `401 access_denied` regardless of root cause. Most common causes: (a) `client_secret` mismatch (rotated in console without updating storage), (b) redirect URI mismatch, (c) authorization code already consumed (single-use).

--- a/scripts/_oauth_stores.py
+++ b/scripts/_oauth_stores.py
@@ -30,9 +30,11 @@ template-via-stdin mode.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import subprocess
+import tempfile
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -53,6 +55,7 @@ class Creds:
 
 class SecretStore(Protocol):
     name: str
+    lock_path: str | None
 
     def read(self) -> Creds: ...
     def write(
@@ -64,6 +67,7 @@ class SecretStore(Protocol):
         expires_at: float | None,
     ) -> None: ...
     def writable(self) -> bool: ...
+    def verify_refresh_token(self, expected: str) -> None: ...
 
 
 _ENV_FIELDS = {
@@ -76,6 +80,7 @@ _ENV_FIELDS = {
 
 class EnvStore:
     name = "env"
+    lock_path: str | None = None
 
     def read(self) -> Creds:
         missing = [
@@ -110,6 +115,10 @@ class EnvStore:
     def writable(self) -> bool:
         return False
 
+    def verify_refresh_token(self, expected: str) -> None:  # noqa: ARG002
+        # Read-only store; nothing to verify.
+        return
+
 
 class OnePasswordStore:
     name = "1password"
@@ -126,6 +135,15 @@ class OnePasswordStore:
         self.item = item
         self.section_creds = section_creds
         self.section_oauth = section_oauth
+        # Same-machine lock keyed by item UUID. Two processes targeting the
+        # same 1Password item will serialize the read-refresh-write critical
+        # section, so neither consumes the other's rotated refresh_token.
+        # Cross-machine concurrency is out of scope (would require a
+        # distributed lock or separate per-runner credentials).
+        digest = hashlib.sha256(item.encode("utf-8")).hexdigest()[:16]
+        self.lock_path = os.path.join(
+            tempfile.gettempdir(), f"mcp_atlassian_oauth_{digest}.lock"
+        )
 
     def _op_read(self, ref: str) -> str:
         # `op` is invoked by name (resolved via PATH); list argv prevents
@@ -173,6 +191,8 @@ class OnePasswordStore:
             "item",
             "edit",
             self.item,
+            "--vault",
+            self.vault,
             f"{self.section_oauth}.access_token={access_token}",
             f"{self.section_oauth}.refresh_token={refresh_token}",
             f"{self.section_oauth}.cloud_id={cloud_id}",
@@ -190,6 +210,25 @@ class OnePasswordStore:
 
     def writable(self) -> bool:
         return True
+
+    def verify_refresh_token(self, expected: str) -> None:
+        """Re-read refresh_token from 1Password and assert it matches.
+
+        Closes the gap where ``op item edit`` exits 0 but the value didn't
+        actually persist (e.g. a concurrent writer overwrote it, or the
+        item shape changed). Without this, the next run might fall back
+        to the consent flow even though we thought we were done.
+        """
+        actual = self._op_read(f"op://{self.vault}/{self.item}/refresh_token")
+        if actual != expected:
+            msg = (
+                "Persisted refresh_token does not match what was just written. "
+                "Either a concurrent process overwrote the field, or the "
+                "OnePasswordStore section/field labels diverged from the "
+                "1Password item shape. Aborting before pytest so the next "
+                "run does not fall back to consent."
+            )
+            raise SecretStoreError(msg)
 
 
 def build_store(

--- a/scripts/_oauth_stores.py
+++ b/scripts/_oauth_stores.py
@@ -1,0 +1,214 @@
+"""Pluggable secret-store backends for the BYO OAuth E2E workflow.
+
+Two backends ship today:
+
+- ``EnvStore`` (default): reads literal environment variables, no write-back.
+  Suitable for contributors without a secret manager and for CI runs where
+  credentials are injected as env vars by the CI system.
+
+- ``OnePasswordStore``: reads + writes via the ``op`` CLI as a child
+  subprocess. Owns ``op`` invocations directly with a list argv (no
+  ``shell=True``), so secret values never pass through a shell string and
+  the rotated refresh token is never visible as a ``$VAR`` expansion in any
+  parent shell history. ``op item edit`` is invoked with
+  ``stdin=subprocess.DEVNULL`` so op does not try to parse the parent's
+  stdin as a JSON template (the documented op-subprocess gotcha from #328).
+
+Adding a new backend (Vault, AWS Secrets Manager, GCP Secret Manager,
+etc.) is a matter of implementing the same ``read()`` / ``write()`` /
+``writable()`` surface; ``oauth_refresh.py`` will pick it up via the
+``--store`` CLI flag.
+
+Argv exposure note: ``op item edit`` accepts field updates as positional
+``"section.field=value"`` arguments. The secret values are briefly visible
+in ``/proc/<pid>/cmdline`` for the lifetime of the ``op`` subprocess (which
+is hundreds of milliseconds at most). On a single-user dev machine this is
+considered acceptable per #328's threat-model discussion. If a stricter
+profile is needed later, switch the write path to ``op item edit``'s
+template-via-stdin mode.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Protocol
+
+logger = logging.getLogger("oauth-store")
+
+
+class SecretStoreError(RuntimeError):
+    """Raised when a secret store cannot satisfy a read or write."""
+
+
+@dataclass
+class Creds:
+    client_id: str
+    client_secret: str
+    refresh_token: str
+    cloud_id: str
+
+
+class SecretStore(Protocol):
+    name: str
+
+    def read(self) -> Creds: ...
+    def write(
+        self,
+        *,
+        access_token: str,
+        refresh_token: str,
+        cloud_id: str,
+        expires_at: float | None,
+    ) -> None: ...
+    def writable(self) -> bool: ...
+
+
+_ENV_FIELDS = {
+    "client_id": "ATLASSIAN_OAUTH_CLIENT_ID",
+    "client_secret": "ATLASSIAN_OAUTH_CLIENT_SECRET",
+    "refresh_token": "CLOUD_E2E_OAUTH_REFRESH_TOKEN",
+    "cloud_id": "CLOUD_E2E_OAUTH_CLOUD_ID",
+}
+
+
+class EnvStore:
+    name = "env"
+
+    def read(self) -> Creds:
+        missing = [
+            env_name
+            for env_name in _ENV_FIELDS.values()
+            if not os.environ.get(env_name)
+        ]
+        if missing:
+            raise SecretStoreError(
+                "env store missing required variables: " + ", ".join(missing)
+            )
+        return Creds(
+            client_id=os.environ[_ENV_FIELDS["client_id"]],
+            client_secret=os.environ[_ENV_FIELDS["client_secret"]],
+            refresh_token=os.environ[_ENV_FIELDS["refresh_token"]],
+            cloud_id=os.environ[_ENV_FIELDS["cloud_id"]],
+        )
+
+    def write(
+        self,
+        *,
+        access_token: str,
+        refresh_token: str,
+        cloud_id: str,
+        expires_at: float | None,
+    ) -> None:
+        logger.warning(
+            "env store cannot persist rotated tokens — set CLOUD_E2E_OAUTH_BACKEND "
+            "or rerun with --store 1password to enable write-back"
+        )
+
+    def writable(self) -> bool:
+        return False
+
+
+class OnePasswordStore:
+    name = "1password"
+
+    def __init__(
+        self,
+        *,
+        vault: str,
+        item: str,
+        section_creds: str = "Atlassian Credentials",
+        section_oauth: str = "OAuth Credentials",
+    ) -> None:
+        self.vault = vault
+        self.item = item
+        self.section_creds = section_creds
+        self.section_oauth = section_oauth
+
+    def _op_read(self, ref: str) -> str:
+        # `op` is invoked by name (resolved via PATH); list argv prevents
+        # any shell handling of the secret reference. Both behaviors are
+        # required for the helper to be usable from any maintainer's
+        # workstation regardless of where 1Password CLI lives.
+        try:
+            result = subprocess.run(
+                ["op", "read", ref],
+                capture_output=True,
+                text=True,
+                check=True,
+                stdin=subprocess.DEVNULL,
+                shell=False,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            msg = f"op read {ref} failed (1Password CLI unavailable or item missing)"
+            raise SecretStoreError(msg) from exc
+        return result.stdout.strip()
+
+    def read(self) -> Creds:
+        base = f"op://{self.vault}/{self.item}"
+        return Creds(
+            client_id=self._op_read(f"{base}/client_id"),
+            client_secret=self._op_read(f"{base}/client_secret"),
+            refresh_token=self._op_read(f"{base}/refresh_token"),
+            cloud_id=self._op_read(f"{base}/cloud_id"),
+        )
+
+    def write(
+        self,
+        *,
+        access_token: str,
+        refresh_token: str,
+        cloud_id: str,
+        expires_at: float | None,
+    ) -> None:
+        # `op item edit` accepts `section.field=value` assignments. Each
+        # assignment is its own argv element — no shell expansion, no
+        # shell-string handling of the rotated refresh_token. stdin is
+        # tied to /dev/null so op doesn't try to read a JSON template
+        # from the parent's stdin.
+        cmd = [
+            "op",
+            "item",
+            "edit",
+            self.item,
+            f"{self.section_oauth}.access_token={access_token}",
+            f"{self.section_oauth}.refresh_token={refresh_token}",
+            f"{self.section_oauth}.cloud_id={cloud_id}",
+        ]
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                stdin=subprocess.DEVNULL,
+                shell=False,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            msg = "op item edit failed; rotated refresh token NOT persisted"
+            raise SecretStoreError(msg) from exc
+
+    def writable(self) -> bool:
+        return True
+
+
+def build_store(
+    name: str,
+    *,
+    op_vault: str | None = None,
+    op_item: str | None = None,
+) -> SecretStore:
+    """Construct a secret store by name.
+
+    Names recognized: ``env``, ``1password``.
+    """
+    if name == "env":
+        return EnvStore()
+    if name == "1password":
+        if not op_vault or not op_item:
+            raise SecretStoreError(
+                "1password store requires --op-vault and --op-item-id (or "
+                "ATLASSIAN_OAUTH_OP_VAULT / ATLASSIAN_OAUTH_OP_ITEM env vars)"
+            )
+        return OnePasswordStore(vault=op_vault, item=op_item)
+    raise SecretStoreError(f"unknown secret store: {name!r}")

--- a/scripts/oauth_authorize.py
+++ b/scripts/oauth_authorize.py
@@ -43,7 +43,6 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.mcp_atlassian.utils.oauth_setup import (
     OAuthSetupArgs,
-    run_oauth_flow,
     run_oauth_flow_returning_config,
 )
 from src.mcp_atlassian.utils.urls import is_atlassian_cloud_url
@@ -144,11 +143,11 @@ def main() -> int:
         persist=not args.no_persist,
     )
 
-    if args.no_persist:
-        oauth_config = run_oauth_flow_returning_config(setup_args)
-        if oauth_config is None:
-            return 1
+    oauth_config = run_oauth_flow_returning_config(setup_args)
+    if oauth_config is None:
+        return 1
 
+    if args.no_persist:
         token_block: dict[str, object] = {
             "access_token": oauth_config.access_token,
             "refresh_token": oauth_config.refresh_token,
@@ -160,10 +159,8 @@ def main() -> int:
             token_block["cloud_id"] = oauth_config.cloud_id
 
         print(json.dumps(token_block, indent=2))
-        return 0
 
-    success = run_oauth_flow(setup_args)
-    return 0 if success else 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/oauth_authorize.py
+++ b/scripts/oauth_authorize.py
@@ -33,6 +33,7 @@ Environment variables can also be used:
 """
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -40,7 +41,11 @@ import sys
 # Add the parent directory to the path so we can import the package
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from src.mcp_atlassian.utils.oauth_setup import OAuthSetupArgs, run_oauth_flow
+from src.mcp_atlassian.utils.oauth_setup import (
+    OAuthSetupArgs,
+    run_oauth_flow,
+    run_oauth_flow_returning_config,
+)
 from src.mcp_atlassian.utils.urls import is_atlassian_cloud_url
 
 logging.basicConfig(
@@ -72,6 +77,16 @@ def main() -> int:
         help="OAuth Redirect URI (e.g., http://localhost:8080/callback)",
     )
     parser.add_argument("--scope", help="OAuth Scope (space-separated)")
+    parser.add_argument(
+        "--no-persist",
+        action="store_true",
+        help=(
+            "Do not write tokens to ~/.mcp-atlassian/ or the OS keyring. "
+            "On success, emit a JSON block with access_token, refresh_token, "
+            "cloud_id, and expires_at to stdout for the caller to capture "
+            "(e.g. into 1Password)."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -126,7 +141,27 @@ def main() -> int:
         redirect_uri=args.redirect_uri,
         scope=args.scope,
         base_url=base_url,
+        persist=not args.no_persist,
     )
+
+    if args.no_persist:
+        oauth_config = run_oauth_flow_returning_config(setup_args)
+        if oauth_config is None:
+            return 1
+
+        token_block: dict[str, object] = {
+            "access_token": oauth_config.access_token,
+            "refresh_token": oauth_config.refresh_token,
+            "expires_at": oauth_config.expires_at,
+        }
+        if oauth_config.is_data_center:
+            token_block["base_url"] = oauth_config.base_url
+        else:
+            token_block["cloud_id"] = oauth_config.cloud_id
+
+        print(json.dumps(token_block, indent=2))
+        return 0
+
     success = run_oauth_flow(setup_args)
     return 0 if success else 1
 

--- a/scripts/oauth_refresh.py
+++ b/scripts/oauth_refresh.py
@@ -90,9 +90,6 @@ def main() -> int:
         return 1
 
     if args.exec:
-        if not args.exec:
-            logger.error("--exec requires a command")
-            return 1
         cmd, *cmd_args = args.exec
         child_env = os.environ.copy()
         child_env["CLOUD_E2E_OAUTH_ACCESS_TOKEN"] = config.access_token or ""

--- a/scripts/oauth_refresh.py
+++ b/scripts/oauth_refresh.py
@@ -34,6 +34,7 @@ import argparse
 import json
 import logging
 import os
+import subprocess
 import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -41,7 +42,6 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from src.mcp_atlassian.utils.oauth import OAuthConfig
 
 logger = logging.getLogger("oauth-refresh")
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
 REQUIRED_ENV_VARS = (
@@ -53,6 +53,12 @@ REQUIRED_ENV_VARS = (
 
 
 def main() -> int:
+    # basicConfig only fires when invoked as a CLI; importing the script
+    # for tests does NOT add a StreamHandler to the root logger, which
+    # would otherwise interfere with pytest's caplog fixture.
+    if not logging.getLogger().hasHandlers():
+        logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
     parser = argparse.ArgumentParser(
         description=(
             "Refresh an Atlassian Cloud OAuth access token from a stored "
@@ -68,7 +74,29 @@ def main() -> int:
             "CLOUD_E2E_OAUTH_CLOUD_ID set in the child environment."
         ),
     )
+    parser.add_argument(
+        "--write-cmd",
+        metavar="SHELL_CMD",
+        help=(
+            "Shell command to run after a successful refresh and before --exec. "
+            "Intended for persisting the rotated refresh_token (Atlassian "
+            "rotates it on every refresh — Cloud refresh tokens are one-shot). "
+            "The command runs with ATLASSIAN_OAUTH_ACCESS_TOKEN, "
+            "ATLASSIAN_OAUTH_REFRESH_TOKEN, ATLASSIAN_OAUTH_CLOUD_ID, and "
+            "ATLASSIAN_OAUTH_EXPIRES_AT in the environment, and stdin tied "
+            "to /dev/null (so `op item edit` doesn't try to parse the "
+            "parent's stdin as a JSON template). If the command exits "
+            "non-zero, oauth_refresh.py exits non-zero without running --exec."
+        ),
+    )
     args = parser.parse_args()
+
+    # argparse.REMAINDER makes `--exec` with no command produce []. Catch
+    # that before we burn a one-shot refresh token on a malformed call
+    # whose JSON output would just go to an uncaptured terminal.
+    if args.exec is not None and not args.exec:
+        logger.error("--exec requires a command")
+        return 1
 
     missing = [name for name in REQUIRED_ENV_VARS if not os.environ.get(name)]
     if missing:
@@ -88,6 +116,27 @@ def main() -> int:
     if not config.refresh_access_token():
         logger.error("Failed to refresh access token")
         return 1
+
+    if args.write_cmd:
+        write_env = os.environ.copy()
+        write_env["ATLASSIAN_OAUTH_ACCESS_TOKEN"] = config.access_token or ""
+        write_env["ATLASSIAN_OAUTH_REFRESH_TOKEN"] = config.refresh_token or ""
+        write_env["ATLASSIAN_OAUTH_CLOUD_ID"] = config.cloud_id or ""
+        write_env["ATLASSIAN_OAUTH_EXPIRES_AT"] = (
+            str(config.expires_at) if config.expires_at is not None else ""
+        )
+        result = subprocess.run(  # noqa: S602
+            args.write_cmd,
+            shell=True,
+            env=write_env,
+            stdin=subprocess.DEVNULL,
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.error(
+                "--write-cmd exited %d; aborting before --exec", result.returncode
+            )
+            return result.returncode
 
     if args.exec:
         cmd, *cmd_args = args.exec

--- a/scripts/oauth_refresh.py
+++ b/scripts/oauth_refresh.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+"""OAuth 2.0 refresh helper for BYO OAuth Cloud E2E tests.
+
+Reads a long-lived refresh_token from the environment, mints a fresh
+access_token via Atlassian's token endpoint, and emits the result without
+persisting anything to ``~/.mcp-atlassian/`` or the OS keyring.
+
+Two output modes:
+
+- **Default (stdout JSON)**: prints a JSON block ``{access_token,
+  refresh_token, cloud_id, expires_at}`` to stdout. The caller can pipe
+  this into ``op item edit`` (or any other secrets-store update tool) to
+  refresh storage.
+
+- **``--exec CMD ARG...``**: sets ``CLOUD_E2E_OAUTH_ACCESS_TOKEN`` and
+  ``CLOUD_E2E_OAUTH_CLOUD_ID`` in the child environment and execs the
+  given command. Designed for wrapping pytest invocations of the BYO
+  OAuth E2E suite so each run gets a fresh access token within
+  Atlassian's ~1-hour expiry window.
+
+Required environment variables:
+
+- ``ATLASSIAN_OAUTH_CLIENT_ID``
+- ``ATLASSIAN_OAUTH_CLIENT_SECRET``
+- ``CLOUD_E2E_OAUTH_REFRESH_TOKEN``
+- ``CLOUD_E2E_OAUTH_CLOUD_ID``
+
+When invoking under ``op run --env-file=.env``, ``op://`` references in
+the env file are substituted by the 1Password CLI before this script
+runs, so this helper itself stays ignorant of any specific secrets store.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.mcp_atlassian.utils.oauth import OAuthConfig
+
+logger = logging.getLogger("oauth-refresh")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+REQUIRED_ENV_VARS = (
+    "ATLASSIAN_OAUTH_CLIENT_ID",
+    "ATLASSIAN_OAUTH_CLIENT_SECRET",
+    "CLOUD_E2E_OAUTH_REFRESH_TOKEN",
+    "CLOUD_E2E_OAUTH_CLOUD_ID",
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Refresh an Atlassian Cloud OAuth access token from a stored "
+            "refresh_token without persisting tokens to disk or the OS keyring."
+        )
+    )
+    parser.add_argument(
+        "--exec",
+        nargs=argparse.REMAINDER,
+        metavar="CMD",
+        help=(
+            "After refresh, exec CMD with CLOUD_E2E_OAUTH_ACCESS_TOKEN and "
+            "CLOUD_E2E_OAUTH_CLOUD_ID set in the child environment."
+        ),
+    )
+    args = parser.parse_args()
+
+    missing = [name for name in REQUIRED_ENV_VARS if not os.environ.get(name)]
+    if missing:
+        logger.error("Missing required environment variables: %s", ", ".join(missing))
+        return 1
+
+    config = OAuthConfig(
+        client_id=os.environ["ATLASSIAN_OAUTH_CLIENT_ID"],
+        client_secret=os.environ["ATLASSIAN_OAUTH_CLIENT_SECRET"],
+        redirect_uri="",
+        scope="",
+        cloud_id=os.environ["CLOUD_E2E_OAUTH_CLOUD_ID"],
+        refresh_token=os.environ["CLOUD_E2E_OAUTH_REFRESH_TOKEN"],
+        persist=False,
+    )
+
+    if not config.refresh_access_token():
+        logger.error("Failed to refresh access token")
+        return 1
+
+    if args.exec:
+        if not args.exec:
+            logger.error("--exec requires a command")
+            return 1
+        cmd, *cmd_args = args.exec
+        child_env = os.environ.copy()
+        child_env["CLOUD_E2E_OAUTH_ACCESS_TOKEN"] = config.access_token or ""
+        child_env["CLOUD_E2E_OAUTH_CLOUD_ID"] = config.cloud_id or ""
+        # User-supplied command is the whole point of --exec. Caller has
+        # explicit control over what is invoked.
+        os.execvpe(cmd, [cmd, *cmd_args], child_env)  # noqa: S606
+        # execvpe replaces the process; this line only reached if exec fails.
+        return 1
+
+    payload = {
+        "access_token": config.access_token,
+        "refresh_token": config.refresh_token,
+        "cloud_id": config.cloud_id,
+        "expires_at": config.expires_at,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/oauth_refresh.py
+++ b/scripts/oauth_refresh.py
@@ -150,6 +150,18 @@ def main() -> int:
         help="1Password item UUID (also: ATLASSIAN_OAUTH_OP_ITEM env var).",
     )
     parser.add_argument(
+        "--reauthorize",
+        action="store_true",
+        help=(
+            "Skip refresh and go straight to the interactive authorize flow. "
+            "Use this when scopes have been added to the Atlassian app's "
+            "Permissions page — a refresh would only mint a new access_token "
+            "under the old scopes, while the user-clicked authorize flow "
+            "issues a token reflecting the latest registration. Requires a "
+            "writable store."
+        ),
+    )
+    parser.add_argument(
         "--allow-rotation-loss",
         action="store_true",
         help=(
@@ -193,6 +205,14 @@ def main() -> int:
         )
         return 1
 
+    if args.reauthorize and not store.writable():
+        logger.error(
+            "--reauthorize requires a writable store; the %s store is read-only "
+            "so the freshly-minted tokens would have nowhere to land.",
+            store.name,
+        )
+        return 1
+
     with _store_lock(store.lock_path):
         try:
             creds = store.read()
@@ -210,7 +230,11 @@ def main() -> int:
             persist=False,
         )
 
-        if not config.refresh_access_token():
+        # Force re-authorization when --reauthorize is set: a refresh would
+        # only mint a new access_token under the old scopes.
+        refresh_succeeded = False if args.reauthorize else config.refresh_access_token()
+
+        if not refresh_succeeded:
             if not store.writable():
                 logger.error(
                     "Refresh failed and the %s store is read-only — re-run "
@@ -221,10 +245,18 @@ def main() -> int:
                 )
                 return 1
 
-            logger.warning(
-                "Refresh failed — falling back to interactive authorize flow. "
-                "A browser window will open; complete consent to mint new tokens."
-            )
+            if args.reauthorize:
+                logger.info(
+                    "--reauthorize: launching interactive authorize flow. "
+                    "A browser window will open; complete consent to mint "
+                    "tokens reflecting the latest scope registration."
+                )
+            else:
+                logger.warning(
+                    "Refresh failed — falling back to interactive authorize "
+                    "flow. A browser window will open; complete consent to "
+                    "mint new tokens."
+                )
             new_config = _reauthorize(creds.client_id, creds.client_secret)
             if new_config is None:
                 logger.error("Authorize flow failed; new tokens NOT minted")

--- a/scripts/oauth_refresh.py
+++ b/scripts/oauth_refresh.py
@@ -45,10 +45,13 @@ Bootstrap (first-time setup) still uses ``scripts/oauth_authorize.py
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import logging
 import os
 import sys
+from collections.abc import Iterator
 
 _SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _SCRIPTS_DIR)
@@ -63,6 +66,30 @@ from src.mcp_atlassian.utils.oauth_setup import (  # noqa: E402
 )
 
 logger = logging.getLogger("oauth-refresh")
+
+
+@contextlib.contextmanager
+def _store_lock(lock_path: str | None) -> Iterator[None]:
+    """Hold an exclusive lock for the duration of the critical section.
+
+    Two processes targeting the same secret store would otherwise consume
+    the same refresh_token, the second one's refresh would fail (Atlassian
+    invalidated the token when the first refresh succeeded), and one of
+    them would burn a rotation that never gets persisted. The lock
+    serializes read → refresh → write per-store.
+    """
+    if lock_path is None:
+        yield
+        return
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 def _reauthorize(client_id: str, client_secret: str) -> OAuthConfig | None:
@@ -123,6 +150,16 @@ def main() -> int:
         help="1Password item UUID (also: ATLASSIAN_OAUTH_OP_ITEM env var).",
     )
     parser.add_argument(
+        "--allow-rotation-loss",
+        action="store_true",
+        help=(
+            "Permit --exec on a read-only store (e.g. 'env') even though the "
+            "rotated refresh_token cannot be persisted. The next run will see "
+            "a stale refresh_token and require re-authorization. Only use this "
+            "in CI runners where credentials are injected per-job."
+        ),
+    )
+    parser.add_argument(
         "--exec",
         nargs=argparse.REMAINDER,
         metavar="CMD",
@@ -141,53 +178,71 @@ def main() -> int:
 
     try:
         store = build_store(args.store, op_vault=args.op_vault, op_item=args.op_item_id)
-        creds = store.read()
     except SecretStoreError as exc:
         logger.error("%s", exc)
         return 1
 
-    config = OAuthConfig(
-        client_id=creds.client_id,
-        client_secret=creds.client_secret,
-        redirect_uri="",
-        scope="",
-        cloud_id=creds.cloud_id,
-        refresh_token=creds.refresh_token,
-        persist=False,
-    )
-
-    if not config.refresh_access_token():
-        if not store.writable():
-            logger.error(
-                "Refresh failed and the %s store is read-only — re-run "
-                "scripts/oauth_authorize.py --no-persist to mint new tokens, "
-                "or switch to a writable store (--store 1password) for "
-                "automatic re-authorization.",
-                store.name,
-            )
-            return 1
-
-        logger.warning(
-            "Refresh failed — falling back to interactive authorize flow. "
-            "A browser window will open; complete consent to mint new tokens."
+    if args.exec and not store.writable() and not args.allow_rotation_loss:
+        logger.error(
+            "Refusing --exec with the read-only %s store: pytest would "
+            "consume the refresh_token, Atlassian would rotate it, but the "
+            "rotated value cannot be persisted back to the store — the next "
+            "run would fail. Either switch to --store 1password, or pass "
+            "--allow-rotation-loss to opt into the rotation-drop (CI only).",
+            store.name,
         )
-        new_config = _reauthorize(creds.client_id, creds.client_secret)
-        if new_config is None:
-            logger.error("Authorize flow failed; new tokens NOT minted")
-            return 1
-        config = new_config
+        return 1
 
-    if store.writable():
+    with _store_lock(store.lock_path):
         try:
-            store.write(
-                access_token=config.access_token or "",
-                refresh_token=config.refresh_token or "",
-                cloud_id=config.cloud_id or "",
-                expires_at=config.expires_at,
-            )
+            creds = store.read()
         except SecretStoreError as exc:
             logger.error("%s", exc)
             return 1
+
+        config = OAuthConfig(
+            client_id=creds.client_id,
+            client_secret=creds.client_secret,
+            redirect_uri="",
+            scope="",
+            cloud_id=creds.cloud_id,
+            refresh_token=creds.refresh_token,
+            persist=False,
+        )
+
+        if not config.refresh_access_token():
+            if not store.writable():
+                logger.error(
+                    "Refresh failed and the %s store is read-only — re-run "
+                    "scripts/oauth_authorize.py --no-persist to mint new tokens, "
+                    "or switch to a writable store (--store 1password) for "
+                    "automatic re-authorization.",
+                    store.name,
+                )
+                return 1
+
+            logger.warning(
+                "Refresh failed — falling back to interactive authorize flow. "
+                "A browser window will open; complete consent to mint new tokens."
+            )
+            new_config = _reauthorize(creds.client_id, creds.client_secret)
+            if new_config is None:
+                logger.error("Authorize flow failed; new tokens NOT minted")
+                return 1
+            config = new_config
+
+        if store.writable():
+            try:
+                store.write(
+                    access_token=config.access_token or "",
+                    refresh_token=config.refresh_token or "",
+                    cloud_id=config.cloud_id or "",
+                    expires_at=config.expires_at,
+                )
+                store.verify_refresh_token(config.refresh_token or "")
+            except SecretStoreError as exc:
+                logger.error("%s", exc)
+                return 1
 
     if args.exec:
         cmd, *cmd_args = args.exec

--- a/scripts/oauth_refresh.py
+++ b/scripts/oauth_refresh.py
@@ -1,69 +1,126 @@
 #!/usr/bin/env python
 """OAuth 2.0 refresh helper for BYO OAuth Cloud E2E tests.
 
-Reads a long-lived refresh_token from the environment, mints a fresh
-access_token via Atlassian's token endpoint, and emits the result without
-persisting anything to ``~/.mcp-atlassian/`` or the OS keyring.
+Reads OAuth credentials from a configured *secret store* (``env`` or
+``1password``), refreshes the access token, persists the rotated refresh
+token back to the store, and either prints a JSON token block to stdout
+or execs a child command (typically ``pytest``) with the fresh access
+token in its environment.
 
-Two output modes:
+Cloud refresh tokens are **single-use** — Atlassian rotates the
+``refresh_token`` on every refresh, invalidating the old one. Storing
+the rotated token back is therefore mandatory for repeatable workflows;
+this script does it transparently when configured against a writable
+store.
 
-- **Default (stdout JSON)**: prints a JSON block ``{access_token,
-  refresh_token, cloud_id, expires_at}`` to stdout. The caller can pipe
-  this into ``op item edit`` (or any other secrets-store update tool) to
-  refresh storage.
+Two stores ship today:
 
-- **``--exec CMD ARG...``**: sets ``CLOUD_E2E_OAUTH_ACCESS_TOKEN`` and
-  ``CLOUD_E2E_OAUTH_CLOUD_ID`` in the child environment and execs the
-  given command. Designed for wrapping pytest invocations of the BYO
-  OAuth E2E suite so each run gets a fresh access token within
-  Atlassian's ~1-hour expiry window.
+- **env** (default): reads literal env vars, no write-back. Suitable for
+  CI runs where the CI system injects credentials, or for one-off use
+  where the rotated token can be captured from the JSON stdout.
 
-Required environment variables:
+- **1password**: reads + writes via the ``op`` CLI as a child subprocess.
+  Owns ``op`` invocations directly with a list argv (no ``shell=True``),
+  so the rotated refresh token never passes through a shell string.
 
-- ``ATLASSIAN_OAUTH_CLIENT_ID``
-- ``ATLASSIAN_OAUTH_CLIENT_SECRET``
-- ``CLOUD_E2E_OAUTH_REFRESH_TOKEN``
-- ``CLOUD_E2E_OAUTH_CLOUD_ID``
+Output modes:
 
-When invoking under ``op run --env-file=.env``, ``op://`` references in
-the env file are substituted by the 1Password CLI before this script
-runs, so this helper itself stays ignorant of any specific secrets store.
+- **Default (stdout JSON)**: prints
+  ``{access_token, refresh_token, cloud_id, expires_at}`` to stdout.
+- **--exec CMD ARG...**: sets ``CLOUD_E2E_OAUTH_ACCESS_TOKEN`` and
+  ``CLOUD_E2E_OAUTH_CLOUD_ID`` in the child environment, then execs the
+  given command. Designed to wrap pytest invocations of the
+  byo_oauth-parametrized tests.
+
+If the refresh request fails (e.g. the stored refresh token is stale)
+**and** the configured store is writable, the script falls back to the
+interactive browser authorize flow and persists the new tokens before
+proceeding. This is the only path that requires a human in the loop —
+the browser consent step.
+
+Bootstrap (first-time setup) still uses ``scripts/oauth_authorize.py
+--no-persist`` for the initial token mint.
 """
+
+from __future__ import annotations
 
 import argparse
 import json
 import logging
 import os
-import subprocess
 import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _SCRIPTS_DIR)
+sys.path.append(os.path.dirname(_SCRIPTS_DIR))
 
-from src.mcp_atlassian.utils.oauth import OAuthConfig
+from _oauth_stores import SecretStoreError, build_store  # noqa: E402
+
+from src.mcp_atlassian.utils.oauth import OAuthConfig  # noqa: E402
+from src.mcp_atlassian.utils.oauth_setup import (  # noqa: E402
+    OAuthSetupArgs,
+    run_oauth_flow_returning_config,
+)
 
 logger = logging.getLogger("oauth-refresh")
 
 
-REQUIRED_ENV_VARS = (
-    "ATLASSIAN_OAUTH_CLIENT_ID",
-    "ATLASSIAN_OAUTH_CLIENT_SECRET",
-    "CLOUD_E2E_OAUTH_REFRESH_TOKEN",
-    "CLOUD_E2E_OAUTH_CLOUD_ID",
-)
+def _reauthorize(client_id: str, client_secret: str) -> OAuthConfig | None:
+    """Run the interactive browser authorize flow as a stale-token fallback.
+
+    Returns the new OAuthConfig on success, None on failure.
+    """
+    redirect_uri = os.environ.get(
+        "ATLASSIAN_OAUTH_REDIRECT_URI", "http://localhost:8080/callback"
+    )
+    scope = os.environ.get("ATLASSIAN_OAUTH_SCOPE")
+    if not scope:
+        logger.error(
+            "Cannot re-authorize: ATLASSIAN_OAUTH_SCOPE is not set. "
+            "Set it to the same scope string used at initial registration."
+        )
+        return None
+
+    setup_args = OAuthSetupArgs(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        scope=scope,
+        persist=False,
+    )
+    return run_oauth_flow_returning_config(setup_args)
 
 
 def main() -> int:
-    # basicConfig only fires when invoked as a CLI; importing the script
-    # for tests does NOT add a StreamHandler to the root logger, which
-    # would otherwise interfere with pytest's caplog fixture.
     if not logging.getLogger().hasHandlers():
         logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(
         description=(
-            "Refresh an Atlassian Cloud OAuth access token from a stored "
-            "refresh_token without persisting tokens to disk or the OS keyring."
+            "Refresh an Atlassian Cloud OAuth access token via a configured "
+            "secret store, persist the rotated refresh token, and optionally "
+            "exec a child command with the fresh credentials in its environment."
         )
+    )
+    parser.add_argument(
+        "--store",
+        choices=["env", "1password"],
+        default=os.environ.get("CLOUD_E2E_OAUTH_BACKEND", "env"),
+        help=(
+            "Secret-store backend (default: %(default)s, also configurable via "
+            "CLOUD_E2E_OAUTH_BACKEND). 'env' reads literal env vars (read-only); "
+            "'1password' reads + writes via the op CLI."
+        ),
+    )
+    parser.add_argument(
+        "--op-vault",
+        default=os.environ.get("ATLASSIAN_OAUTH_OP_VAULT"),
+        help="1Password vault UUID (also: ATLASSIAN_OAUTH_OP_VAULT env var).",
+    )
+    parser.add_argument(
+        "--op-item-id",
+        default=os.environ.get("ATLASSIAN_OAUTH_OP_ITEM"),
+        help="1Password item UUID (also: ATLASSIAN_OAUTH_OP_ITEM env var).",
     )
     parser.add_argument(
         "--exec",
@@ -74,78 +131,70 @@ def main() -> int:
             "CLOUD_E2E_OAUTH_CLOUD_ID set in the child environment."
         ),
     )
-    parser.add_argument(
-        "--write-cmd",
-        metavar="SHELL_CMD",
-        help=(
-            "Shell command to run after a successful refresh and before --exec. "
-            "Intended for persisting the rotated refresh_token (Atlassian "
-            "rotates it on every refresh — Cloud refresh tokens are one-shot). "
-            "The command runs with ATLASSIAN_OAUTH_ACCESS_TOKEN, "
-            "ATLASSIAN_OAUTH_REFRESH_TOKEN, ATLASSIAN_OAUTH_CLOUD_ID, and "
-            "ATLASSIAN_OAUTH_EXPIRES_AT in the environment, and stdin tied "
-            "to /dev/null (so `op item edit` doesn't try to parse the "
-            "parent's stdin as a JSON template). If the command exits "
-            "non-zero, oauth_refresh.py exits non-zero without running --exec."
-        ),
-    )
     args = parser.parse_args()
 
-    # argparse.REMAINDER makes `--exec` with no command produce []. Catch
-    # that before we burn a one-shot refresh token on a malformed call
-    # whose JSON output would just go to an uncaptured terminal.
+    # argparse.REMAINDER makes `--exec` with no command produce []. Reject
+    # that before we burn a one-shot refresh token on a malformed call.
     if args.exec is not None and not args.exec:
         logger.error("--exec requires a command")
         return 1
 
-    missing = [name for name in REQUIRED_ENV_VARS if not os.environ.get(name)]
-    if missing:
-        logger.error("Missing required environment variables: %s", ", ".join(missing))
+    try:
+        store = build_store(args.store, op_vault=args.op_vault, op_item=args.op_item_id)
+        creds = store.read()
+    except SecretStoreError as exc:
+        logger.error("%s", exc)
         return 1
 
     config = OAuthConfig(
-        client_id=os.environ["ATLASSIAN_OAUTH_CLIENT_ID"],
-        client_secret=os.environ["ATLASSIAN_OAUTH_CLIENT_SECRET"],
+        client_id=creds.client_id,
+        client_secret=creds.client_secret,
         redirect_uri="",
         scope="",
-        cloud_id=os.environ["CLOUD_E2E_OAUTH_CLOUD_ID"],
-        refresh_token=os.environ["CLOUD_E2E_OAUTH_REFRESH_TOKEN"],
+        cloud_id=creds.cloud_id,
+        refresh_token=creds.refresh_token,
         persist=False,
     )
 
     if not config.refresh_access_token():
-        logger.error("Failed to refresh access token")
-        return 1
-
-    if args.write_cmd:
-        write_env = os.environ.copy()
-        write_env["ATLASSIAN_OAUTH_ACCESS_TOKEN"] = config.access_token or ""
-        write_env["ATLASSIAN_OAUTH_REFRESH_TOKEN"] = config.refresh_token or ""
-        write_env["ATLASSIAN_OAUTH_CLOUD_ID"] = config.cloud_id or ""
-        write_env["ATLASSIAN_OAUTH_EXPIRES_AT"] = (
-            str(config.expires_at) if config.expires_at is not None else ""
-        )
-        result = subprocess.run(  # noqa: S602
-            args.write_cmd,
-            shell=True,
-            env=write_env,
-            stdin=subprocess.DEVNULL,
-            check=False,
-        )
-        if result.returncode != 0:
+        if not store.writable():
             logger.error(
-                "--write-cmd exited %d; aborting before --exec", result.returncode
+                "Refresh failed and the %s store is read-only — re-run "
+                "scripts/oauth_authorize.py --no-persist to mint new tokens, "
+                "or switch to a writable store (--store 1password) for "
+                "automatic re-authorization.",
+                store.name,
             )
-            return result.returncode
+            return 1
+
+        logger.warning(
+            "Refresh failed — falling back to interactive authorize flow. "
+            "A browser window will open; complete consent to mint new tokens."
+        )
+        new_config = _reauthorize(creds.client_id, creds.client_secret)
+        if new_config is None:
+            logger.error("Authorize flow failed; new tokens NOT minted")
+            return 1
+        config = new_config
+
+    if store.writable():
+        try:
+            store.write(
+                access_token=config.access_token or "",
+                refresh_token=config.refresh_token or "",
+                cloud_id=config.cloud_id or "",
+                expires_at=config.expires_at,
+            )
+        except SecretStoreError as exc:
+            logger.error("%s", exc)
+            return 1
 
     if args.exec:
         cmd, *cmd_args = args.exec
         child_env = os.environ.copy()
         child_env["CLOUD_E2E_OAUTH_ACCESS_TOKEN"] = config.access_token or ""
         child_env["CLOUD_E2E_OAUTH_CLOUD_ID"] = config.cloud_id or ""
-        # User-supplied command is the whole point of --exec. Caller has
-        # explicit control over what is invoked.
-        os.execvpe(cmd, [cmd, *cmd_args], child_env)  # noqa: S606
+        os.execvpe(cmd, [cmd, *cmd_args], child_env)
         # execvpe replaces the process; this line only reached if exec fails.
         return 1
 

--- a/src/mcp_atlassian/utils/oauth.py
+++ b/src/mcp_atlassian/utils/oauth.py
@@ -69,6 +69,7 @@ class OAuthConfig:
     refresh_token: str | None = None
     access_token: str | None = None
     expires_at: float | None = None
+    persist: bool = True
 
     def __post_init__(self) -> None:
         """Validate mutual exclusivity of cloud_id and base_url."""
@@ -354,6 +355,8 @@ class OAuthConfig:
         This allows the tokens to be reused between runs without requiring
         the user to go through the authorization flow again.
         """
+        if not self.persist:
+            return
         try:
             username = self._get_keyring_username()
             base_username = f"oauth-{self.client_id}"

--- a/src/mcp_atlassian/utils/oauth_setup.py
+++ b/src/mcp_atlassian/utils/oauth_setup.py
@@ -208,10 +208,28 @@ class OAuthSetupArgs:
     redirect_uri: str
     scope: str
     base_url: str | None = None
+    persist: bool = True
 
 
 def run_oauth_flow(args: OAuthSetupArgs) -> bool:
-    """Run the OAuth 2.0 authorization flow."""
+    """Run the OAuth 2.0 authorization flow.
+
+    Backwards-compatible wrapper that returns ``True`` on success and
+    ``False`` on failure. For callers that need access to the resulting
+    ``OAuthConfig`` (e.g. emitting tokens to stdout under ``--no-persist``),
+    use :func:`run_oauth_flow_returning_config` instead.
+    """
+    return run_oauth_flow_returning_config(args) is not None
+
+
+def run_oauth_flow_returning_config(args: OAuthSetupArgs) -> OAuthConfig | None:
+    """Run the OAuth 2.0 authorization flow and return the populated config.
+
+    Returns the :class:`OAuthConfig` instance with ``access_token``,
+    ``refresh_token``, and ``cloud_id`` populated on success. Returns
+    ``None`` on any failure (server start, callback, state mismatch,
+    token exchange).
+    """
     # Reset global state (important for multiple runs)
     global authorization_code, authorization_state, callback_received, callback_error
     authorization_code = None
@@ -226,6 +244,7 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
         redirect_uri=args.redirect_uri,
         scope=args.scope,
         base_url=args.base_url,
+        persist=args.persist,
     )
 
     # Generate a random state for CSRF protection
@@ -244,7 +263,7 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
         except OSError as e:
             logger.error(f"Failed to start callback server: {e}")
             logger.error(f"Make sure port {port} is available and not in use")
-            return False
+            return None
 
     # Get the authorization URL
     auth_url = oauth_config.get_authorization_url(state=state)
@@ -260,14 +279,14 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
     if not wait_for_callback():
         if httpd:
             httpd.shutdown()
-        return False
+        return None
 
     # Verify state to prevent CSRF attacks
     if authorization_state != state:
         logger.error("State mismatch! Possible CSRF attack.")
         if httpd:
             httpd.shutdown()
-        return False
+        return None
 
     # Exchange the code for tokens
     logger.info("Exchanging authorization code for tokens...")
@@ -282,21 +301,27 @@ def run_oauth_flow(args: OAuthSetupArgs) -> bool:
                 "and require re-authentication."
             )
 
-        if oauth_config.is_data_center:
-            _log_dc_success(oauth_config)
-        elif oauth_config.cloud_id:
-            _log_cloud_success(oauth_config)
-        else:
+        # Storage-specific success logging only applies when tokens are
+        # actually being persisted. With persist=False, the caller is
+        # responsible for emitting the tokens (e.g. JSON to stdout).
+        if oauth_config.persist:
+            if oauth_config.is_data_center:
+                _log_dc_success(oauth_config)
+            elif oauth_config.cloud_id:
+                _log_cloud_success(oauth_config)
+            else:
+                logger.error("Failed to obtain cloud ID!")
+        elif not oauth_config.is_data_center and not oauth_config.cloud_id:
             logger.error("Failed to obtain cloud ID!")
 
         if httpd:
             httpd.shutdown()
-        return True
+        return oauth_config
     else:
         logger.error("Failed to exchange authorization code for tokens")
         if httpd:
             httpd.shutdown()
-        return False
+        return None
 
 
 def _log_cloud_success(oauth_config: OAuthConfig) -> None:

--- a/tests/unit/scripts/test_oauth_authorize.py
+++ b/tests/unit/scripts/test_oauth_authorize.py
@@ -1,9 +1,10 @@
 """Tests for the scripts/oauth_authorize.py CLI script."""
 
 import importlib.util
+import json
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 def _load_script_module():
@@ -120,3 +121,105 @@ class TestOAuthAuthorizeScript:
                 mod.main()
         # No warning about offline_access for DC
         assert "offline_access" not in caplog.text
+
+    def test_no_persist_flag_propagates(self):
+        """--no-persist sets OAuthSetupArgs.persist=False."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--client-id",
+            "X",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "read:jira-work offline_access",
+            "--no-persist",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                mock_flow.return_value = None  # exit non-zero, skip stdout assertions
+                mod.main()
+        mock_flow.assert_called_once()
+        args = mock_flow.call_args[0][0]
+        assert args.persist is False
+
+    def test_default_omits_no_persist(self):
+        """Without --no-persist, OAuthSetupArgs.persist=True (back-compat)."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--client-id",
+            "X",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "read:jira-work offline_access",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch.object(mod, "run_oauth_flow") as mock_flow:
+                mock_flow.return_value = True
+                mod.main()
+        mock_flow.assert_called_once()
+        args = mock_flow.call_args[0][0]
+        assert args.persist is True
+
+    def test_no_persist_emits_json_to_stdout(self, capsys):
+        """--no-persist on success emits JSON token block to stdout."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--client-id",
+            "X",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "read:jira-work offline_access",
+            "--no-persist",
+        ]
+
+        fake_config = MagicMock()
+        fake_config.access_token = "fake-access"
+        fake_config.refresh_token = "fake-refresh"
+        fake_config.cloud_id = "fake-cloud"
+        fake_config.expires_at = 9999999999.0
+        fake_config.is_data_center = False
+        fake_config.base_url = None
+
+        with patch.object(sys, "argv", argv):
+            with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                mock_flow.return_value = fake_config
+                result = mod.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["access_token"] == "fake-access"
+        assert payload["refresh_token"] == "fake-refresh"
+        assert payload["cloud_id"] == "fake-cloud"
+
+    def test_no_persist_failure_returns_nonzero(self):
+        """--no-persist when flow returns None exits with code 1."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--client-id",
+            "X",
+            "--client-secret",
+            "Y",
+            "--redirect-uri",
+            "http://localhost:8080/callback",
+            "--scope",
+            "read:jira-work offline_access",
+            "--no-persist",
+        ]
+        with patch.object(sys, "argv", argv):
+            with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                mock_flow.return_value = None
+                result = mod.main()
+        assert result == 1

--- a/tests/unit/scripts/test_oauth_authorize.py
+++ b/tests/unit/scripts/test_oauth_authorize.py
@@ -40,8 +40,8 @@ class TestOAuthAuthorizeScript:
             "WRITE",
         ]
         with patch.object(sys, "argv", argv):
-            with patch.object(mod, "run_oauth_flow") as mock_flow:
-                mock_flow.return_value = True
+            with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                mock_flow.return_value = MagicMock()
                 result = mod.main()
         assert result == 0
         mock_flow.assert_called_once()
@@ -65,8 +65,8 @@ class TestOAuthAuthorizeScript:
             "read:jira-work offline_access",
         ]
         with patch.object(sys, "argv", argv):
-            with patch.object(mod, "run_oauth_flow") as mock_flow:
-                mock_flow.return_value = True
+            with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                mock_flow.return_value = MagicMock()
                 result = mod.main()
         assert result == 0
         mock_flow.assert_called_once()
@@ -91,8 +91,8 @@ class TestOAuthAuthorizeScript:
         }
         with patch.object(sys, "argv", argv):
             with patch.dict(os.environ, env, clear=False):
-                with patch.object(mod, "run_oauth_flow") as mock_flow:
-                    mock_flow.return_value = True
+                with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                    mock_flow.return_value = MagicMock()
                     result = mod.main()
         assert result == 0
         mock_flow.assert_called_once()
@@ -116,8 +116,8 @@ class TestOAuthAuthorizeScript:
             "WRITE",
         ]
         with patch.object(sys, "argv", argv):
-            with patch.object(mod, "run_oauth_flow") as mock_flow:
-                mock_flow.return_value = True
+            with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                mock_flow.return_value = MagicMock()
                 mod.main()
         # No warning about offline_access for DC
         assert "offline_access" not in caplog.text
@@ -160,8 +160,8 @@ class TestOAuthAuthorizeScript:
             "read:jira-work offline_access",
         ]
         with patch.object(sys, "argv", argv):
-            with patch.object(mod, "run_oauth_flow") as mock_flow:
-                mock_flow.return_value = True
+            with patch.object(mod, "run_oauth_flow_returning_config") as mock_flow:
+                mock_flow.return_value = MagicMock()
                 mod.main()
         mock_flow.assert_called_once()
         args = mock_flow.call_args[0][0]

--- a/tests/unit/scripts/test_oauth_refresh.py
+++ b/tests/unit/scripts/test_oauth_refresh.py
@@ -15,7 +15,7 @@ import importlib.util
 import json
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 
 def _load_script_module():
@@ -39,24 +39,26 @@ REQUIRED_ENV = {
 
 
 class TestOAuthRefreshScript:
-    def test_errors_when_required_env_var_missing(self, caplog):
+    def test_errors_when_required_env_var_missing(self):
         """Missing env vars produce a clear error and non-zero exit."""
-        import logging
-
         mod = _load_script_module()
         argv = ["prog"]
-        # Missing ATLASSIAN_OAUTH_CLIENT_SECRET
         env = {
             k: v
             for k, v in REQUIRED_ENV.items()
             if k != "ATLASSIAN_OAUTH_CLIENT_SECRET"
         }
-        with caplog.at_level(logging.ERROR):
-            with patch.object(sys, "argv", argv):
-                with patch.dict(os.environ, env, clear=True):
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, env, clear=True):
+                with patch.object(mod.logger, "error") as mock_error:
                     rc = mod.main()
         assert rc != 0
-        assert "ATLASSIAN_OAUTH_CLIENT_SECRET" in caplog.text
+        # Logger called with format-string + args, not pre-formatted.
+        all_messages = " ".join(
+            (call.args[0] % call.args[1:]) if len(call.args) > 1 else str(call.args[0])
+            for call in mock_error.call_args_list
+        )
+        assert "ATLASSIAN_OAUTH_CLIENT_SECRET" in all_messages
 
     def test_emits_refreshed_token_as_json(self, capsys):
         """Default mode prints a JSON token block to stdout."""
@@ -100,6 +102,125 @@ class TestOAuthRefreshScript:
                 ):
                     rc = mod.main()
         assert rc != 0
+
+    def test_exec_with_no_command_errors_before_refresh(self, caplog):
+        """--exec with no command must reject early, before consuming refresh token.
+
+        argparse.REMAINDER produces args.exec == [] when --exec is passed
+        with nothing after it. Falling through to default JSON mode would
+        consume (and rotate) the refresh token while silently printing it
+        to a terminal the caller didn't intend to capture.
+        """
+        import logging
+
+        mod = _load_script_module()
+        argv = ["prog", "--exec"]
+
+        refresh_calls = []
+
+        def fake_refresh(self):
+            refresh_calls.append(1)
+            return True
+
+        with caplog.at_level(logging.ERROR):
+            with patch.object(sys, "argv", argv):
+                with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                    with patch(
+                        "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                        fake_refresh,
+                    ):
+                        rc = mod.main()
+
+        assert rc != 0
+        assert refresh_calls == []
+        assert "--exec requires a command" in caplog.text
+
+    def test_write_cmd_runs_with_rotated_refresh_token_in_env(self):
+        """--write-cmd receives the rotated refresh token via env vars."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--write-cmd",
+            "true",
+            "--exec",
+            "pytest",
+        ]
+
+        def fake_refresh(self):
+            self.access_token = "fresh-access"
+            self.refresh_token = "ROTATED-refresh"
+            self.expires_at = 9999.0
+            return True
+
+        captured: dict[str, object] = {}
+
+        def fake_subprocess_run(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                with patch(
+                    "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                    fake_refresh,
+                ):
+                    with patch("subprocess.run", side_effect=fake_subprocess_run):
+                        with patch("os.execvpe"):
+                            mod.main()
+
+        assert captured["args"][0] == "true"
+        kwargs = captured["kwargs"]
+        env = kwargs["env"]
+        assert env["ATLASSIAN_OAUTH_ACCESS_TOKEN"] == "fresh-access"
+        assert env["ATLASSIAN_OAUTH_REFRESH_TOKEN"] == "ROTATED-refresh"
+        assert env["ATLASSIAN_OAUTH_CLOUD_ID"] == "test-cloud-id"
+        assert env["ATLASSIAN_OAUTH_EXPIRES_AT"] == "9999.0"
+        # stdin must be DEVNULL so `op item edit` doesn't try to parse
+        # the parent's stdin as a JSON template.
+        import subprocess
+
+        assert kwargs["stdin"] == subprocess.DEVNULL
+
+    def test_write_cmd_failure_aborts_before_exec(self, caplog):
+        """If --write-cmd exits nonzero, --exec must not run."""
+        import logging
+
+        mod = _load_script_module()
+        argv = ["prog", "--write-cmd", "false", "--exec", "pytest"]
+
+        def fake_refresh(self):
+            self.access_token = "fresh"
+            self.refresh_token = "rotated"
+            self.expires_at = 1.0
+            return True
+
+        exec_calls = []
+
+        def fake_subprocess_run(*_args, **_kwargs):
+            result = MagicMock()
+            result.returncode = 7
+            return result
+
+        with caplog.at_level(logging.ERROR):
+            with patch.object(sys, "argv", argv):
+                with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                    with patch(
+                        "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                        fake_refresh,
+                    ):
+                        with patch("subprocess.run", side_effect=fake_subprocess_run):
+                            with patch(
+                                "os.execvpe",
+                                side_effect=lambda *a, **k: exec_calls.append(a),
+                            ):
+                                rc = mod.main()
+
+        assert rc == 7
+        assert exec_calls == []
+        assert "--write-cmd exited" in caplog.text
 
     def test_exec_mode_sets_env_and_execs(self):
         """--exec passes refreshed access_token + cloud_id into child env."""

--- a/tests/unit/scripts/test_oauth_refresh.py
+++ b/tests/unit/scripts/test_oauth_refresh.py
@@ -135,31 +135,105 @@ class TestOAuthRefreshScript:
         assert refresh_calls == []
         assert "--exec requires a command" in caplog.text
 
-    def test_write_cmd_runs_with_rotated_refresh_token_in_env(self):
-        """--write-cmd receives the rotated refresh token via env vars."""
+    def test_store_1password_full_flow_refresh_persist_exec(self):
+        """--store 1password reads via op, refreshes, writes rotated tokens, execs."""
+        import subprocess
+
         mod = _load_script_module()
         argv = [
             "prog",
-            "--write-cmd",
-            "true",
+            "--store",
+            "1password",
+            "--op-vault",
+            "VAULT-UUID",
+            "--op-item-id",
+            "ITEM-UUID",
             "--exec",
             "pytest",
+            "-k",
+            "byo_oauth",
         ]
+
+        op_calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def fake_run(cmd, **kwargs):
+            op_calls.append((list(cmd), dict(kwargs)))
+            result = MagicMock()
+            if list(cmd[:2]) == ["op", "read"]:
+                # Field is the last URL component.
+                field = cmd[2].split("/")[-1]
+                result.stdout = f"stored-{field}\n"
+            result.returncode = 0
+            return result
 
         def fake_refresh(self):
             self.access_token = "fresh-access"
             self.refresh_token = "ROTATED-refresh"
-            self.expires_at = 9999.0
+            self.expires_at = 1234.5
             return True
 
-        captured: dict[str, object] = {}
+        execvpe_calls: list[tuple] = []
 
-        def fake_subprocess_run(*args, **kwargs):
-            captured["args"] = args
-            captured["kwargs"] = kwargs
-            result = MagicMock()
-            result.returncode = 0
-            return result
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("subprocess.run", side_effect=fake_run):
+                    with patch(
+                        "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                        fake_refresh,
+                    ):
+                        with patch(
+                            "os.execvpe",
+                            side_effect=lambda *a, **k: execvpe_calls.append(a),
+                        ):
+                            mod.main()
+
+        # Four `op read` calls (one per field) and one `op item edit`.
+        read_cmds = [cmd for cmd, _ in op_calls if cmd[:2] == ["op", "read"]]
+        edit_cmds = [cmd for cmd, _ in op_calls if cmd[:3] == ["op", "item", "edit"]]
+        assert len(read_cmds) == 4
+        assert len(edit_cmds) == 1
+        edit_cmd = edit_cmds[0]
+        # Rotated refresh_token must appear as discrete arg-list element.
+        assert any("refresh_token=ROTATED-refresh" in arg for arg in edit_cmd)
+        assert any("access_token=fresh-access" in arg for arg in edit_cmd)
+        # No invocation may use shell=True.
+        assert all(kw.get("shell", False) is False for _, kw in op_calls)
+        # `op item edit` must use stdin=DEVNULL.
+        edit_kwargs = next(
+            kw for cmd, kw in op_calls if cmd[:3] == ["op", "item", "edit"]
+        )
+        assert edit_kwargs["stdin"] == subprocess.DEVNULL
+        # Then exec'd pytest with the fresh access token.
+        assert execvpe_calls
+        execvpe_args = execvpe_calls[0]
+        assert execvpe_args[0] == "pytest"
+        assert execvpe_args[2]["CLOUD_E2E_OAUTH_ACCESS_TOKEN"] == "fresh-access"
+
+    def test_store_1password_missing_uuids_errors(self):
+        """--store 1password without --op-vault/--op-item-id errors clearly."""
+        mod = _load_script_module()
+        argv = ["prog", "--store", "1password"]
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, {}, clear=True):
+                with patch.object(mod.logger, "error") as mock_error:
+                    rc = mod.main()
+        assert rc != 0
+        all_messages = " ".join(
+            str(call.args[0]) % call.args[1:]
+            if len(call.args) > 1
+            else str(call.args[0])
+            for call in mock_error.call_args_list
+        )
+        assert "1password" in all_messages.lower()
+
+    def test_stale_refresh_token_with_readonly_store_returns_error(self):
+        """With env store (read-only), refresh failure returns nonzero with guidance."""
+        mod = _load_script_module()
+        argv = ["prog", "--store", "env"]
+
+        def fake_refresh(self):
+            return False
 
         with patch.object(sys, "argv", argv):
             with patch.dict(os.environ, REQUIRED_ENV, clear=True):
@@ -167,60 +241,67 @@ class TestOAuthRefreshScript:
                     "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
                     fake_refresh,
                 ):
-                    with patch("subprocess.run", side_effect=fake_subprocess_run):
-                        with patch("os.execvpe"):
-                            mod.main()
+                    with patch.object(mod.logger, "error") as mock_error:
+                        rc = mod.main()
+        assert rc != 0
+        all_messages = " ".join(
+            str(call.args[0]) % call.args[1:]
+            if len(call.args) > 1
+            else str(call.args[0])
+            for call in mock_error.call_args_list
+        )
+        assert "oauth_authorize.py" in all_messages
 
-        assert captured["args"][0] == "true"
-        kwargs = captured["kwargs"]
-        env = kwargs["env"]
-        assert env["ATLASSIAN_OAUTH_ACCESS_TOKEN"] == "fresh-access"
-        assert env["ATLASSIAN_OAUTH_REFRESH_TOKEN"] == "ROTATED-refresh"
-        assert env["ATLASSIAN_OAUTH_CLOUD_ID"] == "test-cloud-id"
-        assert env["ATLASSIAN_OAUTH_EXPIRES_AT"] == "9999.0"
-        # stdin must be DEVNULL so `op item edit` doesn't try to parse
-        # the parent's stdin as a JSON template.
-        import subprocess
-
-        assert kwargs["stdin"] == subprocess.DEVNULL
-
-    def test_write_cmd_failure_aborts_before_exec(self, caplog):
-        """If --write-cmd exits nonzero, --exec must not run."""
-        import logging
-
+    def test_stale_refresh_token_with_writable_store_invokes_authorize(self):
+        """1P store + refresh failure → authorize flow runs and persists new tokens."""
         mod = _load_script_module()
-        argv = ["prog", "--write-cmd", "false", "--exec", "pytest"]
+        argv = [
+            "prog",
+            "--store",
+            "1password",
+            "--op-vault",
+            "V",
+            "--op-item-id",
+            "I",
+        ]
 
-        def fake_refresh(self):
-            self.access_token = "fresh"
-            self.refresh_token = "rotated"
-            self.expires_at = 1.0
-            return True
-
-        exec_calls = []
-
-        def fake_subprocess_run(*_args, **_kwargs):
+        def fake_run(cmd, **kwargs):
             result = MagicMock()
-            result.returncode = 7
+            if list(cmd[:2]) == ["op", "read"]:
+                field = cmd[2].split("/")[-1]
+                result.stdout = f"stored-{field}\n"
+            result.returncode = 0
             return result
 
-        with caplog.at_level(logging.ERROR):
-            with patch.object(sys, "argv", argv):
-                with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+        def fake_refresh(self):
+            return False
+
+        new_config = MagicMock()
+        new_config.access_token = "post-authorize-access"
+        new_config.refresh_token = "post-authorize-refresh"
+        new_config.cloud_id = "post-authorize-cloud"
+        new_config.expires_at = 9999.0
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(
+                os.environ,
+                {"ATLASSIAN_OAUTH_SCOPE": "read:jira-work offline_access"},
+                clear=True,
+            ):
+                with patch("subprocess.run", side_effect=fake_run):
                     with patch(
                         "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
                         fake_refresh,
                     ):
-                        with patch("subprocess.run", side_effect=fake_subprocess_run):
-                            with patch(
-                                "os.execvpe",
-                                side_effect=lambda *a, **k: exec_calls.append(a),
-                            ):
-                                rc = mod.main()
+                        with patch.object(
+                            mod,
+                            "run_oauth_flow_returning_config",
+                            return_value=new_config,
+                        ) as mock_authorize:
+                            rc = mod.main()
 
-        assert rc == 7
-        assert exec_calls == []
-        assert "--write-cmd exited" in caplog.text
+        assert rc == 0
+        mock_authorize.assert_called_once()
 
     def test_exec_mode_sets_env_and_execs(self):
         """--exec passes refreshed access_token + cloud_id into child env."""

--- a/tests/unit/scripts/test_oauth_refresh.py
+++ b/tests/unit/scripts/test_oauth_refresh.py
@@ -1,0 +1,135 @@
+"""Tests for the scripts/oauth_refresh.py CLI script.
+
+The refresh helper takes a long-lived refresh_token and mints a fresh
+access_token without persisting anything to disk or the OS keyring.
+Two output modes:
+
+- Default: JSON token block to stdout (callers pipe into ``op item edit``
+  or similar to update external storage).
+- ``--exec CMD ARG...``: sets ``CLOUD_E2E_OAUTH_ACCESS_TOKEN`` and
+  ``CLOUD_E2E_OAUTH_CLOUD_ID`` in the child environment and execs the
+  command. Used to wrap pytest invocations for the BYO OAuth E2E suite.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import patch
+
+
+def _load_script_module():
+    script_path = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "scripts", "oauth_refresh.py"
+    )
+    script_path = os.path.abspath(script_path)
+    spec = importlib.util.spec_from_file_location("oauth_refresh", script_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+REQUIRED_ENV = {
+    "ATLASSIAN_OAUTH_CLIENT_ID": "test-client-id",
+    "ATLASSIAN_OAUTH_CLIENT_SECRET": "test-client-secret",
+    "CLOUD_E2E_OAUTH_REFRESH_TOKEN": "test-refresh-token",
+    "CLOUD_E2E_OAUTH_CLOUD_ID": "test-cloud-id",
+}
+
+
+class TestOAuthRefreshScript:
+    def test_errors_when_required_env_var_missing(self, caplog):
+        """Missing env vars produce a clear error and non-zero exit."""
+        import logging
+
+        mod = _load_script_module()
+        argv = ["prog"]
+        # Missing ATLASSIAN_OAUTH_CLIENT_SECRET
+        env = {
+            k: v
+            for k, v in REQUIRED_ENV.items()
+            if k != "ATLASSIAN_OAUTH_CLIENT_SECRET"
+        }
+        with caplog.at_level(logging.ERROR):
+            with patch.object(sys, "argv", argv):
+                with patch.dict(os.environ, env, clear=True):
+                    rc = mod.main()
+        assert rc != 0
+        assert "ATLASSIAN_OAUTH_CLIENT_SECRET" in caplog.text
+
+    def test_emits_refreshed_token_as_json(self, capsys):
+        """Default mode prints a JSON token block to stdout."""
+        mod = _load_script_module()
+        argv = ["prog"]
+
+        def fake_refresh(self):
+            self.access_token = "fresh-access"
+            self.refresh_token = "rotated-refresh"
+            self.expires_at = 9999.0
+            return True
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                with patch(
+                    "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                    fake_refresh,
+                ):
+                    rc = mod.main()
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["access_token"] == "fresh-access"
+        assert payload["refresh_token"] == "rotated-refresh"
+        assert payload["cloud_id"] == "test-cloud-id"
+
+    def test_refresh_failure_returns_nonzero(self):
+        """When refresh_access_token returns False, exit non-zero."""
+        mod = _load_script_module()
+        argv = ["prog"]
+
+        def fake_refresh(self):
+            return False
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                with patch(
+                    "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                    fake_refresh,
+                ):
+                    rc = mod.main()
+        assert rc != 0
+
+    def test_exec_mode_sets_env_and_execs(self):
+        """--exec passes refreshed access_token + cloud_id into child env."""
+        mod = _load_script_module()
+        argv = ["prog", "--exec", "pytest", "-k", "byo_oauth"]
+
+        def fake_refresh(self):
+            self.access_token = "fresh-access"
+            self.refresh_token = "rotated-refresh"
+            self.expires_at = 9999.0
+            return True
+
+        recorded: dict[str, object] = {}
+
+        def fake_execvpe(file: str, argv_: list[str], env: dict[str, str]) -> None:
+            recorded["file"] = file
+            recorded["argv"] = argv_
+            recorded["env"] = env
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                with patch(
+                    "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                    fake_refresh,
+                ):
+                    with patch("os.execvpe", side_effect=fake_execvpe):
+                        mod.main()
+
+        assert recorded["file"] == "pytest"
+        assert recorded["argv"] == ["pytest", "-k", "byo_oauth"]
+        env = recorded["env"]
+        assert env["CLOUD_E2E_OAUTH_ACCESS_TOKEN"] == "fresh-access"
+        assert env["CLOUD_E2E_OAUTH_CLOUD_ID"] == "test-cloud-id"

--- a/tests/unit/scripts/test_oauth_refresh.py
+++ b/tests/unit/scripts/test_oauth_refresh.py
@@ -155,14 +155,23 @@ class TestOAuthRefreshScript:
         ]
 
         op_calls: list[tuple[list[str], dict[str, object]]] = []
+        refresh_read_count = [0]
 
         def fake_run(cmd, **kwargs):
             op_calls.append((list(cmd), dict(kwargs)))
             result = MagicMock()
             if list(cmd[:2]) == ["op", "read"]:
-                # Field is the last URL component.
-                field = cmd[2].split("/")[-1]
-                result.stdout = f"stored-{field}\n"
+                ref = cmd[2]
+                if ref.endswith("/refresh_token"):
+                    refresh_read_count[0] += 1
+                    # First read: stored value. Second read: verify-after-write.
+                    result.stdout = (
+                        "ROTATED-refresh\n"
+                        if refresh_read_count[0] >= 2
+                        else "stored-refresh_token\n"
+                    )
+                else:
+                    result.stdout = f"stored-{ref.split('/')[-1]}\n"
             result.returncode = 0
             return result
 
@@ -187,10 +196,11 @@ class TestOAuthRefreshScript:
                         ):
                             mod.main()
 
-        # Four `op read` calls (one per field) and one `op item edit`.
+        # Five `op read` calls (4 initial fields + 1 verify-after-write) and
+        # one `op item edit`.
         read_cmds = [cmd for cmd, _ in op_calls if cmd[:2] == ["op", "read"]]
         edit_cmds = [cmd for cmd, _ in op_calls if cmd[:3] == ["op", "item", "edit"]]
-        assert len(read_cmds) == 4
+        assert len(read_cmds) == 5
         assert len(edit_cmds) == 1
         edit_cmd = edit_cmds[0]
         # Rotated refresh_token must appear as discrete arg-list element.
@@ -252,6 +262,248 @@ class TestOAuthRefreshScript:
         )
         assert "oauth_authorize.py" in all_messages
 
+    def test_env_store_with_exec_refuses_without_allow_rotation_loss(self):
+        """--store env --exec refuses by default — rotation would be lost."""
+        mod = _load_script_module()
+        argv = ["prog", "--store", "env", "--exec", "pytest"]
+
+        refresh_calls = []
+
+        def fake_refresh(self):
+            refresh_calls.append(1)
+            return True
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                with patch(
+                    "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                    fake_refresh,
+                ):
+                    with patch.object(mod.logger, "error") as mock_error:
+                        rc = mod.main()
+        assert rc != 0
+        assert refresh_calls == []
+        all_messages = " ".join(str(call.args[0]) for call in mock_error.call_args_list)
+        assert "rotation" in all_messages.lower()
+
+    def test_env_store_with_exec_and_allow_flag_proceeds(self):
+        """--allow-rotation-loss escape hatch lets --exec run on env store."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--store",
+            "env",
+            "--exec",
+            "pytest",
+            "--allow-rotation-loss",
+        ]
+
+        def fake_refresh(self):
+            self.access_token = "fresh"
+            self.refresh_token = "rotated"
+            self.expires_at = 1.0
+            return True
+
+        execvpe_calls: list = []
+        # --exec eats the rest of argv via REMAINDER, so --allow-rotation-loss
+        # must be placed BEFORE --exec to be parsed as a flag.
+        argv = [
+            "prog",
+            "--store",
+            "env",
+            "--allow-rotation-loss",
+            "--exec",
+            "pytest",
+        ]
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                with patch(
+                    "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                    fake_refresh,
+                ):
+                    with patch(
+                        "os.execvpe",
+                        side_effect=lambda *a, **k: execvpe_calls.append(a),
+                    ):
+                        mod.main()
+        assert execvpe_calls
+
+    def test_1password_store_calls_verify_after_write(self):
+        """After op item edit, OnePasswordStore.verify_refresh_token must run."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--store",
+            "1password",
+            "--op-vault",
+            "V",
+            "--op-item-id",
+            "I",
+        ]
+
+        def fake_run(cmd, **_kwargs):
+            result = MagicMock()
+            if list(cmd[:2]) == ["op", "read"]:
+                # Returns the rotated value on the verify-after-write call
+                # so verify passes; for initial reads, return placeholders.
+                field = cmd[2].split("/")[-1]
+                if field == "refresh_token":
+                    # First read → original; second read (verify) → rotated.
+                    result.stdout = (
+                        "ROTATED-rt\n"
+                        if "verify-marker" in str(_kwargs.get("_marker", ""))
+                        else f"original-{field}\n"
+                    )
+                else:
+                    result.stdout = f"value-of-{field}\n"
+            result.returncode = 0
+            return result
+
+        # Simpler approach: track call order and serve the right value per call.
+        read_calls: list[str] = []
+
+        def fake_run_v2(cmd, **_kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            if list(cmd[:2]) == ["op", "read"]:
+                ref = cmd[2]
+                read_calls.append(ref)
+                if ref.endswith("/refresh_token"):
+                    # First refresh_token read → stored; second (verify) → rotated.
+                    refresh_reads = [
+                        r for r in read_calls if r.endswith("/refresh_token")
+                    ]
+                    result.stdout = (
+                        "ROTATED-rt\n" if len(refresh_reads) > 1 else "stored-rt\n"
+                    )
+                else:
+                    result.stdout = f"value-of-{ref.split('/')[-1]}\n"
+            return result
+
+        def fake_refresh(self):
+            self.access_token = "ATOK"
+            self.refresh_token = "ROTATED-rt"
+            self.expires_at = 9999.0
+            return True
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("subprocess.run", side_effect=fake_run_v2):
+                    with patch(
+                        "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                        fake_refresh,
+                    ):
+                        rc = mod.main()
+        assert rc == 0
+        # Two refresh_token reads: initial credentials read + verify-after-write.
+        refresh_reads = [r for r in read_calls if r.endswith("/refresh_token")]
+        assert len(refresh_reads) == 2
+
+    def test_1password_store_aborts_when_verify_after_write_mismatches(self):
+        """If verify reads a different value than we wrote, abort with non-zero exit."""
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--store",
+            "1password",
+            "--op-vault",
+            "V",
+            "--op-item-id",
+            "I",
+            "--exec",
+            "pytest",
+        ]
+
+        read_call_count: list[int] = [0]
+
+        def fake_run(cmd, **_kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            if list(cmd[:2]) == ["op", "read"]:
+                ref = cmd[2]
+                if ref.endswith("/refresh_token"):
+                    read_call_count[0] += 1
+                    # Verify (second refresh_token read) returns a DIFFERENT value.
+                    if read_call_count[0] >= 2:
+                        result.stdout = "WRONG-VALUE\n"
+                    else:
+                        result.stdout = "stored-rt\n"
+                else:
+                    result.stdout = f"value-of-{ref.split('/')[-1]}\n"
+            return result
+
+        def fake_refresh(self):
+            self.access_token = "ATOK"
+            self.refresh_token = "ROTATED-rt"
+            self.expires_at = 9999.0
+            return True
+
+        execvpe_calls: list = []
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("subprocess.run", side_effect=fake_run):
+                    with patch(
+                        "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                        fake_refresh,
+                    ):
+                        with patch(
+                            "os.execvpe",
+                            side_effect=lambda *a, **k: execvpe_calls.append(a),
+                        ):
+                            rc = mod.main()
+        assert rc != 0
+        assert execvpe_calls == []
+
+    def test_lock_acquired_around_critical_section(self):
+        """When the store has a lock_path, fcntl.flock(LOCK_EX) is called.
+
+        Defends against two local processes consuming the same refresh_token
+        concurrently and racing the write-back.
+        """
+        import fcntl
+
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--store",
+            "1password",
+            "--op-vault",
+            "V",
+            "--op-item-id",
+            "I",
+        ]
+
+        flock_calls: list[int] = []
+
+        def fake_flock(_fd, op):
+            flock_calls.append(op)
+
+        def fake_run(cmd, **_kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            if list(cmd[:2]) == ["op", "read"]:
+                result.stdout = f"value-of-{cmd[2].split('/')[-1]}\n"
+            return result
+
+        def fake_refresh(self):
+            self.access_token = "a"
+            self.refresh_token = "r"
+            self.expires_at = 1.0
+            return True
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, {}, clear=True):
+                with patch("subprocess.run", side_effect=fake_run):
+                    with patch(
+                        "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                        fake_refresh,
+                    ):
+                        with patch("fcntl.flock", side_effect=fake_flock):
+                            mod.main()
+        assert fcntl.LOCK_EX in flock_calls
+
     def test_stale_refresh_token_with_writable_store_invokes_authorize(self):
         """1P store + refresh failure → authorize flow runs and persists new tokens."""
         mod = _load_script_module()
@@ -265,11 +517,18 @@ class TestOAuthRefreshScript:
             "I",
         ]
 
+        verify_marker = ["pre"]
+
         def fake_run(cmd, **kwargs):
             result = MagicMock()
             if list(cmd[:2]) == ["op", "read"]:
-                field = cmd[2].split("/")[-1]
-                result.stdout = f"stored-{field}\n"
+                ref = cmd[2]
+                if ref.endswith("/refresh_token") and verify_marker[0] == "post":
+                    # Verify-after-write call returns the rotated token.
+                    result.stdout = "post-authorize-refresh\n"
+                else:
+                    field = ref.split("/")[-1]
+                    result.stdout = f"stored-{field}\n"
             result.returncode = 0
             return result
 
@@ -281,6 +540,12 @@ class TestOAuthRefreshScript:
         new_config.refresh_token = "post-authorize-refresh"
         new_config.cloud_id = "post-authorize-cloud"
         new_config.expires_at = 9999.0
+
+        # Authorize flow returning new_config flips the marker so subsequent
+        # refresh_token reads (verify-after-write) return the rotated value.
+        def fake_authorize(*_a, **_k):
+            verify_marker[0] = "post"
+            return new_config
 
         with patch.object(sys, "argv", argv):
             with patch.dict(
@@ -296,7 +561,7 @@ class TestOAuthRefreshScript:
                         with patch.object(
                             mod,
                             "run_oauth_flow_returning_config",
-                            return_value=new_config,
+                            side_effect=fake_authorize,
                         ) as mock_authorize:
                             rc = mod.main()
 
@@ -306,7 +571,16 @@ class TestOAuthRefreshScript:
     def test_exec_mode_sets_env_and_execs(self):
         """--exec passes refreshed access_token + cloud_id into child env."""
         mod = _load_script_module()
-        argv = ["prog", "--exec", "pytest", "-k", "byo_oauth"]
+        # env store + --exec requires --allow-rotation-loss (the rotated
+        # refresh_token cannot be persisted by the env store).
+        argv = [
+            "prog",
+            "--allow-rotation-loss",
+            "--exec",
+            "pytest",
+            "-k",
+            "byo_oauth",
+        ]
 
         def fake_refresh(self):
             self.access_token = "fresh-access"

--- a/tests/unit/scripts/test_oauth_refresh.py
+++ b/tests/unit/scripts/test_oauth_refresh.py
@@ -262,6 +262,86 @@ class TestOAuthRefreshScript:
         )
         assert "oauth_authorize.py" in all_messages
 
+    def test_reauthorize_flag_skips_refresh_and_invokes_authorize(self):
+        """--reauthorize bypasses refresh and goes straight to authorize.
+
+        Use case: the operator just added scopes to their Atlassian app.
+        A normal refresh would mint a new access_token under the OLD
+        scopes; only a fresh authorize gets the new ones.
+        """
+        mod = _load_script_module()
+        argv = [
+            "prog",
+            "--store",
+            "1password",
+            "--op-vault",
+            "V",
+            "--op-item-id",
+            "I",
+            "--reauthorize",
+        ]
+
+        refresh_calls = []
+
+        def fake_refresh(self):
+            refresh_calls.append(1)
+            return True
+
+        def fake_run(cmd, **_kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            if list(cmd[:2]) == ["op", "read"]:
+                ref = cmd[2]
+                if ref.endswith("/refresh_token"):
+                    # Verify-after-write returns the new value.
+                    result.stdout = "post-authorize-refresh\n"
+                else:
+                    result.stdout = f"value-of-{ref.split('/')[-1]}\n"
+            return result
+
+        new_config = MagicMock()
+        new_config.access_token = "post-authorize-access"
+        new_config.refresh_token = "post-authorize-refresh"
+        new_config.cloud_id = "post-authorize-cloud"
+        new_config.expires_at = 9999.0
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(
+                os.environ,
+                {"ATLASSIAN_OAUTH_SCOPE": "read:jira-work offline_access"},
+                clear=True,
+            ):
+                with patch("subprocess.run", side_effect=fake_run):
+                    with patch(
+                        "src.mcp_atlassian.utils.oauth.OAuthConfig.refresh_access_token",
+                        fake_refresh,
+                    ):
+                        with patch.object(
+                            mod,
+                            "run_oauth_flow_returning_config",
+                            return_value=new_config,
+                        ) as mock_authorize:
+                            rc = mod.main()
+
+        assert rc == 0
+        # Refresh must NOT be called when --reauthorize is set.
+        assert refresh_calls == []
+        # Authorize must run.
+        mock_authorize.assert_called_once()
+
+    def test_reauthorize_with_readonly_store_errors(self):
+        """--reauthorize on a read-only store errors — nowhere to write."""
+        mod = _load_script_module()
+        argv = ["prog", "--store", "env", "--reauthorize"]
+
+        with patch.object(sys, "argv", argv):
+            with patch.dict(os.environ, REQUIRED_ENV, clear=True):
+                with patch.object(mod.logger, "error") as mock_error:
+                    rc = mod.main()
+        assert rc != 0
+        all_messages = " ".join(str(call.args[0]) for call in mock_error.call_args_list)
+        assert "writable" in all_messages.lower() or "read-only" in all_messages.lower()
+
     def test_env_store_with_exec_refuses_without_allow_rotation_loss(self):
         """--store env --exec refuses by default — rotation would be lost."""
         mod = _load_script_module()

--- a/tests/unit/scripts/test_oauth_stores.py
+++ b/tests/unit/scripts/test_oauth_stores.py
@@ -1,0 +1,158 @@
+"""Tests for scripts/_oauth_stores.py — pluggable secret-store backends.
+
+Two backends:
+- EnvStore: reads literal env vars, no write-back.
+- OnePasswordStore: reads + writes via `op` CLI subprocess, no shell.
+
+The OnePasswordStore must:
+- Use subprocess.run with a list (shell=False) so secrets never pass through
+  a shell string — neither in expansion nor in argv-of-a-shell.
+- Pass stdin=subprocess.DEVNULL on `op item edit` so op doesn't try to
+  parse the parent's stdin as a JSON template (the documented op gotcha).
+- Read each field via `op read op://<vault>/<item>/<field>`.
+- Write all rotated fields in a single `op item edit` invocation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _load_module():
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "scripts", "_oauth_stores.py"
+        )
+    )
+    spec = importlib.util.spec_from_file_location("_oauth_stores", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_oauth_stores"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestEnvStore:
+    def test_read_returns_credentials_from_env(self):
+        mod = _load_module()
+        env = {
+            "ATLASSIAN_OAUTH_CLIENT_ID": "cid",
+            "ATLASSIAN_OAUTH_CLIENT_SECRET": "csec",
+            "CLOUD_E2E_OAUTH_REFRESH_TOKEN": "rtok",
+            "CLOUD_E2E_OAUTH_CLOUD_ID": "cloud",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            creds = mod.EnvStore().read()
+        assert creds.client_id == "cid"
+        assert creds.client_secret == "csec"
+        assert creds.refresh_token == "rtok"
+        assert creds.cloud_id == "cloud"
+
+    def test_read_raises_clear_error_when_missing(self):
+        mod = _load_module()
+        with patch.dict(os.environ, {}, clear=True):
+            try:
+                mod.EnvStore().read()
+            except mod.SecretStoreError as exc:
+                assert "ATLASSIAN_OAUTH_CLIENT_ID" in str(exc)
+            else:
+                raise AssertionError("expected SecretStoreError")
+
+    def test_writable_is_false(self):
+        mod = _load_module()
+        assert mod.EnvStore().writable() is False
+
+    def test_write_is_noop_with_warning(self, caplog):
+        import logging
+
+        mod = _load_module()
+        with caplog.at_level(logging.WARNING):
+            mod.EnvStore().write(
+                access_token="a", refresh_token="r", cloud_id="c", expires_at=1.0
+            )
+        assert "env store cannot persist" in caplog.text.lower()
+
+
+class TestOnePasswordStore:
+    def test_read_uses_op_read_per_field_no_shell(self):
+        mod = _load_module()
+
+        captured: list[tuple[list[str], dict[str, object]]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append((list(cmd), kwargs))
+            field = cmd[-1].split("/")[-1]
+            result = MagicMock()
+            result.stdout = f"value-of-{field}\n"
+            result.returncode = 0
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            creds = mod.OnePasswordStore(vault="VAULT", item="ITEM").read()
+
+        assert creds.client_id == "value-of-client_id"
+        assert creds.refresh_token == "value-of-refresh_token"
+        # All four reads must be op subprocess invocations, list form (no shell).
+        assert len(captured) == 4
+        for cmd, kwargs in captured:
+            assert cmd[0] == "op"
+            assert cmd[1] == "read"
+            assert cmd[2].startswith("op://VAULT/ITEM/")
+            assert kwargs.get("shell", False) is False
+            assert kwargs.get("stdin") == subprocess.DEVNULL
+
+    def test_write_invokes_op_item_edit_no_shell_devnull_stdin(self):
+        mod = _load_module()
+
+        captured: dict[str, object] = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["kwargs"] = kwargs
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            mod.OnePasswordStore(vault="V", item="ITEM").write(
+                access_token="ATOK",
+                refresh_token="RTOK-ROTATED",
+                cloud_id="C",
+                expires_at=1234.5,
+            )
+
+        cmd = captured["cmd"]
+        kwargs = captured["kwargs"]
+        # First three positional args: op item edit ITEM
+        assert cmd[:3] == ["op", "item", "edit"]
+        assert "ITEM" in cmd
+        # Each rotated field appears as a discrete arg-list element so the
+        # secret never passes through a shell string.
+        assigns = [arg for arg in cmd if "=" in arg]
+        assert any("access_token=ATOK" in a for a in assigns)
+        assert any("refresh_token=RTOK-ROTATED" in a for a in assigns)
+        assert kwargs.get("shell", False) is False
+        assert kwargs.get("stdin") == subprocess.DEVNULL
+        assert kwargs.get("check", False) is True
+
+    def test_writable_is_true(self):
+        mod = _load_module()
+        assert mod.OnePasswordStore(vault="v", item="i").writable() is True
+
+    def test_read_raises_secretstoreerror_on_op_failure(self):
+        mod = _load_module()
+
+        def fake_run(*_a, **_k):
+            raise subprocess.CalledProcessError(returncode=1, cmd=["op"])
+
+        with patch("subprocess.run", side_effect=fake_run):
+            try:
+                mod.OnePasswordStore(vault="v", item="i").read()
+            except mod.SecretStoreError as exc:
+                assert "op read" in str(exc).lower() or "1password" in str(exc).lower()
+            else:
+                raise AssertionError("expected SecretStoreError")

--- a/tests/unit/scripts/test_oauth_stores.py
+++ b/tests/unit/scripts/test_oauth_stores.py
@@ -156,3 +156,96 @@ class TestOnePasswordStore:
                 assert "op read" in str(exc).lower() or "1password" in str(exc).lower()
             else:
                 raise AssertionError("expected SecretStoreError")
+
+    def test_write_includes_vault_flag(self):
+        """`op item edit` invocation must scope to the vault, not just the item.
+
+        Read uses op://VAULT/ITEM/field — write should be symmetric.
+        """
+        mod = _load_module()
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            captured.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            mod.OnePasswordStore(vault="VAULT-UUID", item="ITEM-UUID").write(
+                access_token="a",
+                refresh_token="r",
+                cloud_id="c",
+                expires_at=1.0,
+            )
+
+        cmd = captured[0]
+        assert "--vault" in cmd
+        assert "VAULT-UUID" in cmd
+        # --vault must appear immediately before the value.
+        idx = cmd.index("--vault")
+        assert cmd[idx + 1] == "VAULT-UUID"
+
+    def test_verify_refresh_token_round_trips_via_op_read(self):
+        """verify_refresh_token re-reads the refresh_token field and asserts match."""
+        mod = _load_module()
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            captured.append(list(cmd))
+            result = MagicMock()
+            result.stdout = "PERSISTED-TOKEN\n"
+            result.returncode = 0
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            mod.OnePasswordStore(vault="V", item="I").verify_refresh_token(
+                "PERSISTED-TOKEN"
+            )
+
+        # Must invoke `op read` against the refresh_token field.
+        assert captured[0][:2] == ["op", "read"]
+        assert "refresh_token" in captured[0][2]
+
+    def test_verify_refresh_token_raises_on_mismatch(self):
+        """If 1Password returns a different value than we wrote, abort loudly."""
+        mod = _load_module()
+
+        def fake_run(*_a, **_k):
+            result = MagicMock()
+            result.stdout = "DIFFERENT-VALUE\n"
+            result.returncode = 0
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            try:
+                mod.OnePasswordStore(vault="V", item="I").verify_refresh_token(
+                    "EXPECTED-TOKEN"
+                )
+            except mod.SecretStoreError as exc:
+                assert (
+                    "refresh_token" in str(exc).lower()
+                    or "mismatch" in str(exc).lower()
+                )
+            else:
+                raise AssertionError("expected SecretStoreError on round-trip mismatch")
+
+    def test_lock_path_is_unique_per_item(self):
+        """Same item UUID → same lock path; different items → different paths."""
+        mod = _load_module()
+        s1 = mod.OnePasswordStore(vault="A", item="ITEM-1")
+        s2 = mod.OnePasswordStore(vault="B", item="ITEM-1")
+        s3 = mod.OnePasswordStore(vault="A", item="ITEM-2")
+        assert s1.lock_path == s2.lock_path
+        assert s1.lock_path != s3.lock_path
+
+    def test_env_store_has_no_lock_path(self):
+        mod = _load_module()
+        assert mod.EnvStore().lock_path is None
+
+    def test_env_store_verify_is_noop(self):
+        """EnvStore.verify_refresh_token does nothing (read-only store)."""
+        mod = _load_module()
+        # Should not raise, should not call subprocess.
+        mod.EnvStore().verify_refresh_token("anything")

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -471,6 +471,39 @@ class TestOAuthConfig:
             assert saved_data["expires_at"] == 1234567890
             assert saved_data["cloud_id"] == "test-cloud-id"
 
+    def test_persist_default_true(self):
+        """OAuthConfig.persist defaults to True (back-compat)."""
+        config = OAuthConfig(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            redirect_uri="https://example.com/callback",
+            scope="read:jira-work",
+        )
+        assert config.persist is True
+
+    @patch("keyring.set_password")
+    @patch.object(OAuthConfig, "_save_tokens_to_file")
+    def test_save_tokens_no_persist_skips_keyring_and_file(
+        self, mock_save_to_file, mock_set_password
+    ):
+        """When persist=False, _save_tokens writes nothing to keyring or disk."""
+        config = OAuthConfig(
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            redirect_uri="https://example.com/callback",
+            scope="read:jira-work",
+            cloud_id="test-cloud-id",
+            refresh_token="test-refresh-token",
+            access_token="test-access-token",
+            expires_at=1234567890,
+            persist=False,
+        )
+
+        config._save_tokens()
+
+        mock_set_password.assert_not_called()
+        mock_save_to_file.assert_not_called()
+
     @patch("keyring.get_password")
     @patch.object(OAuthConfig, "_load_tokens_from_file")
     def test_load_tokens_keyring_success(self, mock_load_from_file, mock_get_password):

--- a/tests/unit/utils/test_oauth.py
+++ b/tests/unit/utils/test_oauth.py
@@ -1156,12 +1156,18 @@ class TestDataCenterOAuth:
         assert config.cloud_id is None
 
     def test_from_env_dc_defaults_redirect_and_scope(self):
-        """DC from_env provides default redirect_uri and scope."""
+        """DC from_env provides default redirect_uri and scope.
+
+        Uses clear=True to be hermetic against earlier tests that may have
+        set ATLASSIAN_OAUTH_REDIRECT_URI or ATLASSIAN_OAUTH_SCOPE without
+        cleaning up — this test specifically asserts the DEFAULT path,
+        which only triggers when those env vars are absent.
+        """
         env = {
             "ATLASSIAN_OAUTH_CLIENT_ID": "dc-client",
             "ATLASSIAN_OAUTH_CLIENT_SECRET": "dc-secret",
         }
-        with patch.dict("os.environ", env, clear=False):
+        with patch.dict("os.environ", env, clear=True):
             config = OAuthConfig.from_env(
                 service_url="https://jira.corp.com",
                 service_type="jira",

--- a/tests/unit/utils/test_oauth_setup.py
+++ b/tests/unit/utils/test_oauth_setup.py
@@ -14,6 +14,7 @@ from mcp_atlassian.utils.oauth_setup import (
     _log_dc_success,
     parse_redirect_uri,
     run_oauth_flow,
+    run_oauth_flow_returning_config,
     run_oauth_setup,
 )
 from tests.utils.assertions import assert_config_contains
@@ -244,6 +245,7 @@ class TestOAuthFlow:
                     redirect_uri="http://localhost:8080/callback",
                     scope="WRITE",
                     base_url=DC_JIRA_URL,
+                    persist=True,
                 )
                 mock_config.exchange_code_for_tokens.assert_called_once_with(
                     "test-auth-code"
@@ -810,6 +812,159 @@ class TestOAuthSetupArgs:
             scope="WRITE",
             base_url=DC_JIRA_URL,
         )
+
+    def test_oauth_setup_args_persist_default_true(self):
+        """OAuthSetupArgs.persist defaults to True (back-compat)."""
+        args = OAuthSetupArgs(
+            client_id="a",
+            client_secret="b",
+            redirect_uri="http://localhost:8080/callback",
+            scope="c",
+        )
+        assert args.persist is True
+
+    def test_oauth_setup_args_persist_can_be_disabled(self):
+        """OAuthSetupArgs.persist=False is accepted."""
+        args = OAuthSetupArgs(
+            client_id="a",
+            client_secret="b",
+            redirect_uri="http://localhost:8080/callback",
+            scope="c",
+            persist=False,
+        )
+        assert args.persist is False
+
+
+class TestRunOAuthFlowReturningConfig:
+    """Tests for run_oauth_flow_returning_config (returns OAuthConfig|None)."""
+
+    @pytest.fixture(autouse=True)
+    def reset_oauth_state(self):
+        import mcp_atlassian.utils.oauth_setup as oauth_module
+
+        oauth_module.authorization_code = None
+        oauth_module.authorization_state = None
+        oauth_module.callback_received = False
+        oauth_module.callback_error = None
+
+    def test_returns_oauth_config_on_success(self):
+        """Returns the OAuthConfig instance with tokens populated."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+            ):
+
+                def setup_callback_state():
+                    import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                    oauth_module.authorization_code = "test-auth-code"
+                    oauth_module.authorization_state = "test-state-token"
+                    return True
+
+                mock_wait.side_effect = setup_callback_state
+                mock_start_server.return_value = MagicMock()
+
+                mock_config = MagicMock()
+                mock_config.exchange_code_for_tokens.return_value = True
+                mock_config.is_data_center = False
+                mock_config.cloud_id = "test-cloud-id"
+                mock_config.persist = True
+                mock_oauth_config.return_value = mock_config
+
+                args = OAuthSetupArgs(
+                    client_id="x",
+                    client_secret="y",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="z",
+                )
+                with patch("mcp_atlassian.utils.oauth_setup._log_cloud_success"):
+                    result = run_oauth_flow_returning_config(args)
+
+                assert result is mock_config
+
+    def test_returns_none_on_token_exchange_failure(self):
+        """Returns None when exchange_code_for_tokens fails."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+            ):
+
+                def setup_callback_state():
+                    import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                    oauth_module.authorization_code = "test-auth-code"
+                    oauth_module.authorization_state = "test-state-token"
+                    return True
+
+                mock_wait.side_effect = setup_callback_state
+                mock_start_server.return_value = MagicMock()
+
+                mock_config = MagicMock()
+                mock_config.exchange_code_for_tokens.return_value = False
+                mock_oauth_config.return_value = mock_config
+
+                args = OAuthSetupArgs(
+                    client_id="x",
+                    client_secret="y",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="z",
+                )
+                result = run_oauth_flow_returning_config(args)
+
+                assert result is None
+
+    def test_propagates_persist_false_to_oauth_config(self):
+        """OAuthSetupArgs(persist=False) constructs OAuthConfig with persist=False."""
+        with MockOAuthServer.mock_oauth_flow():
+            with (
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.OAuthConfig"
+                ) as mock_oauth_config,
+                patch("mcp_atlassian.utils.oauth_setup.wait_for_callback") as mock_wait,
+                patch(
+                    "mcp_atlassian.utils.oauth_setup.start_callback_server"
+                ) as mock_start_server,
+            ):
+
+                def setup_callback_state():
+                    import mcp_atlassian.utils.oauth_setup as oauth_module
+
+                    oauth_module.authorization_code = "test-auth-code"
+                    oauth_module.authorization_state = "test-state-token"
+                    return True
+
+                mock_wait.side_effect = setup_callback_state
+                mock_start_server.return_value = MagicMock()
+
+                mock_config = MagicMock()
+                mock_config.exchange_code_for_tokens.return_value = True
+                mock_config.is_data_center = False
+                mock_config.cloud_id = "test-cloud-id"
+                mock_config.persist = False
+                mock_oauth_config.return_value = mock_config
+
+                args = OAuthSetupArgs(
+                    client_id="x",
+                    client_secret="y",
+                    redirect_uri="http://localhost:8080/callback",
+                    scope="z",
+                    persist=False,
+                )
+                run_oauth_flow_returning_config(args)
+
+                assert mock_oauth_config.call_args.kwargs["persist"] is False
 
 
 class TestConfigurationGeneration:


### PR DESCRIPTION
## Summary

Productizes the BYO OAuth E2E test workflow so the `byo_oauth`-parametrized cloud tests run with a single command and self-heal across token rotation, eliminating the manual ritual called out in #328. Maintainers using 1Password get end-to-end automation; contributors using literal env vars (e.g. CI) work the same as before.

The maintainer experience:

```bash
op run --env-file=.env -- \
  uv run python scripts/oauth_refresh.py \
    --store 1password \
    --exec uv run pytest tests/e2e/cloud/ -k byo_oauth --cloud-e2e -W error
```

Reads creds from 1Password → refreshes the access token → persists the rotated refresh token back to 1Password (with verify-after-write) → execs pytest with the fresh credentials. No shell incantation, no manual cleanup, no `~/.mcp-atlassian/` tokens lingering. Cloud refresh tokens are single-use; the helper handles rotation transparently.

## Architecture

Nine commits, layered:

1. **`OAuthConfig.persist`** — gates `_save_tokens()`. Default `True` (back-compat).
2. **`OAuthSetupArgs.persist` plumbing + `run_oauth_flow_returning_config`** — exposes the populated config so callers can serialize tokens themselves; `run_oauth_flow` stays as a thin bool wrapper.
3. **`scripts/oauth_authorize.py --no-persist`** — bootstrap path. JSON token block to stdout, no keyring/file writes.
4. **`oauth_authorize.py` simplification** — unifies the persist and no-persist paths through the single returning-config function.
5. **`scripts/oauth_refresh.py` (initial shape)** — wrapper for refresh + exec. _Heavily refactored by commit 7._
6. **`a21b9fc` — rotation persistence** — surfaced rotated refresh tokens. _Superseded by the 1Password backend in commit 7._
7. **`scripts/_oauth_stores.py` + `--store {env,1password}`** — pluggable secret-store backend owned by the script. `OnePasswordStore` invokes `op` directly via subprocess (no shell, list argv, `stdin=DEVNULL`). Drops `--write-cmd` entirely. Adds stale-token auto-recovery via the interactive authorize flow.
8. **Hardening (`69e8c68`)** — verify-after-write, file-lock around the read-refresh-write critical section, `--allow-rotation-loss` guard on `--exec` with read-only stores, narrow ruff S-rule ignore, pre-existing flake fix in `test_from_env_dc_defaults_redirect_and_scope`.
9. **`--reauthorize` flag (`b1a06c2`)** — operator-facing escape hatch for "I just changed scopes on the Atlassian app": skips the refresh attempt (which would only mint under the old consented scopes) and goes straight to the interactive authorize flow.

## Convergence guarantees

The maintainer-facing run, `oauth_refresh.py --store 1password --exec ...`, satisfies all five layers:

- **Single-consent recovery**: stale refresh token → fall back to interactive authorize, persist new tokens, exec — one browser click. Subsequent runs find the rotated token in storage and refresh silently.
- **Rotation persisted**: every `OAuthConfig.refresh_access_token()` call is followed by `store.write(...)` then `store.verify_refresh_token(rotated)` against 1Password. `op item edit` returning 0 isn't trusted on its own.
- **Concurrency-safe**: `fcntl.LOCK_EX` around read → refresh → write, keyed by `sha256(item_uuid)`. Two local processes serialize on the same item; neither consumes the other's rotated refresh_token.
- **No silent rotation drop**: `--store env --exec` is refused unless `--allow-rotation-loss` is passed (intended only for CI runners that inject fresh creds per-job).
- **Secret-store hygiene on `op` invocations**: list argv (no `shell=True`), `stdin=DEVNULL` (avoids op's JSON-template parsing of the parent's stdin), `--vault` scoping symmetric with `op read`.

## Live verification

Validated against a real Atlassian Cloud instance under `--cloud-e2e -W error`:

| Run | Trigger | Refresh path | Persist | Tests |
|---|---|---|---|---|
| #1 | stale stored token | authorize flow (one consent) | ✅ verify-after-write OK | 13 pass |
| #2 | run again immediately | silent refresh | ✅ verify-after-write OK | 13 pass |
| #3 | `--reauthorize` after adding new scope | authorize flow (one consent) | ✅ verify-after-write OK | 13 pass |

Run #2 demonstrates the convergence target: zero consent, rotation persisted, tests run end-to-end.

## Known failure: `test_search[byo_oauth]` — tracked separately as #335

One of the 14 `byo_oauth`-parametrized tests (`test_confluence_auth_matrix.py::TestConfluenceReadOperations::test_search`) fails with `401 Unauthorized; scope does not match` on `GET /rest/api/search`, even after registering and consenting to the full classic + granular scope matrix (`read:confluence-content.summary`, `read:confluence-content.all`, `read:confluence-space.summary`, `search:confluence`, plus all granular `read:*:confluence` / `write:*:confluence` scopes — verified by decoding the issued JWT). Atlassian appears to have tightened scope requirements on this OAuth-routed v1 endpoint in a way that doesn't match any documented scope set.

The fix is a v2 adapter migration mirroring PR #330 (`get_spaces`) — out of scope for #328's BYO OAuth tooling concerns. Tracked as **#335: Migrate ConfluenceFetcher.search() (CQL) from v1 to v2**. Basic-auth runs of the same test pass, so the test failure is specifically the OAuth path.

## Test plan

- [x] **Unit suite**: 3027 passed, 5 skipped with `-W error`. New tests cover both stores plus the refactored refresh flow:
  - `test_oauth_stores.py`: EnvStore + OnePasswordStore read/write/verify, vault-on-edit, lock-path uniqueness.
  - `test_oauth_refresh.py`: `--store 1password` full flow with subprocess assertions (no shell, DEVNULL stdin), `--store env --exec` refusal, `--allow-rotation-loss` opt-in, `--reauthorize` skip-refresh-go-to-authorize, verify-after-write happy path + mismatch abort, `fcntl.LOCK_EX` acquired around the critical section, stale-token authorize fallback.
- [x] **Pre-commit**: ruff-format, ruff (narrowed `S101/S603/S606/S607` ignore on `scripts/`), mypy clean.
- [x] **Live cloud E2E**: 13/14 `byo_oauth` tests pass against a real Atlassian Cloud instance under `--cloud-e2e -W error`. Verified `~/.mcp-atlassian/` remains untouched (no leak; WSL has no functional keyring backend so file-fallback is the only meaningful gate on this dev machine). Single failure (`test_search`) tracked as #335.

## Acceptance criteria (#328)

- [x] 14 `byo_oauth` cloud E2E tests run without manual post-flow cleanup. *(13 pass; the 14th fails for an Atlassian scope-on-v1-endpoint reason unrelated to the BYO OAuth tooling — see #335.)*
- [x] `oauth_authorize.py --no-persist` leaves nothing in `~/.mcp-atlassian/` or the OS keyring.
- [x] Contributors without 1Password populate `.env.example` placeholders directly (`--store env`).
- [x] `op://` references and 1P UUIDs in committed docs use placeholders (no maintainer-specific identifiers).

## Notes

- Adding a future backend (Vault, AWS Secrets Manager, GCP Secret Manager, etc.) is one Python class implementing `SecretStore`; `oauth_refresh.py` picks it up via `--store`.
- Cross-machine concurrency on the same 1Password item would require a distributed lock or per-runner credentials. Out of scope; the local file lock catches the realistic case (one maintainer, one workstation, multiple terminals/agents).
- Argv-exposure of secrets to `op item edit` is bounded by op's own subprocess lifetime (hundreds of milliseconds); shell-string and shell-expansion exposure is fully eliminated. Stricter hardening via `op item edit` template-via-stdin is a possible future change if the threat model tightens.

Closes #328
